### PR TITLE
Feat: Set up Atomic Design structure with initial atoms

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,7 @@
 import type { Preview } from '@storybook/nextjs-vite';
 
+import '../src/styles/globals.css';
+
 const preview: Preview = {
   parameters: {
     controls: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "flowit",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-slot": "^1.2.3",
         "@tanstack/react-query": "^5.81.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -3074,6 +3076,85 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
@@ -4507,7 +4588,7 @@
       "version": "20.19.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.4.tgz",
       "integrity": "sha512-OP+We5WV8Xnbuvw0zC2m4qfB/BJvjyCwtNjhHdJxV1639SGSKrLmJkc3fMnp2Qy8nJyHp8RO6umxELN/dS1/EA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4517,7 +4598,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4527,7 +4608,7 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -6990,7 +7071,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -13993,7 +14074,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -14138,7 +14219,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "test:vitest": "vitest"
   },
   "dependencies": {
+    "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.81.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/atoms/Icon/Icon.stories.tsx
+++ b/src/components/atoms/Icon/Icon.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Icon } from './Icon';
+
+const meta: Meta<typeof Icon> = {
+  title: 'Components/Atoms/Icon',
+  component: Icon,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    name: {
+      control: 'select',
+      options: ['pin', 'trash', 'edit', 'check', 'circle', 'more'],
+      description: '표시할 아이콘의 이름을 선택합니다.',
+    },
+    size: {
+      control: 'number',
+      description: '아이콘의 크기를 픽셀 단위로 설정합니다.',
+    },
+    color: {
+      control: 'color',
+      description: '아이콘의 색상을 설정합니다.',
+    },
+    strokeWidth: {
+      control: 'number',
+      description: '아이콘 선의 두께를 설정합니다.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Icon>;
+
+export const PinIcon: Story = {
+  args: {
+    name: 'pin',
+    size: 24,
+    color: '#333',
+  },
+};
+
+export const TrashIcon: Story = {
+  args: {
+    name: 'trash',
+    size: 24,
+    color: '#FF4D4D',
+  },
+};
+
+export const EditIcon: Story = {
+  args: {
+    name: 'edit',
+    size: 24,
+    color: '#1890FF',
+  },
+};
+
+export const CheckIcon: Story = {
+  args: {
+    name: 'check',
+    size: 24,
+    color: '#52C41A',
+  },
+};
+
+export const CircleIcon: Story = {
+  args: {
+    name: 'circle',
+    size: 24,
+    color: '#BFBFBF',
+  },
+};
+
+export const MoreIcon: Story = {
+  args: {
+    name: 'more',
+    size: 24,
+    color: '#333',
+  },
+};
+
+export const MoreVerticalIcon: Story = {
+  args: {
+    name: 'more-vertical',
+    size: 24,
+    color: '#333',
+  },
+};

--- a/src/components/atoms/Icon/Icon.tsx
+++ b/src/components/atoms/Icon/Icon.tsx
@@ -1,0 +1,43 @@
+import {
+  CheckCircle2,
+  Circle,
+  EllipsisVertical,
+  LucideProps, // lucide-react에서 제공하는 기본 props 타입
+  MoreHorizontal,
+  Pencil,
+  Pin,
+  Trash2,
+} from 'lucide-react';
+
+// 프로젝트에서 사용할 아이콘의 이름을 타입으로 정의합니다.
+// 새로운 아이콘을 사용하고 싶으면 해당하는 아이콘을 https://lucide.dev/icons/에서 찾아 import하고
+// 여기에 이름을 추가하기만 하면 됩니다.
+export type IconName = 'pin' | 'trash' | 'edit' | 'check' | 'circle' | 'more' | 'more-vertical';
+
+// Icon 컴포넌트의 props 타입을 정의합니다.
+// lucide-react의 기본 props를 상속받아 size, color 등을 그대로 사용할 수 있습니다.
+interface IconProps extends LucideProps {
+  name: IconName;
+}
+
+// name prop에 따라 적절한 아이콘을 렌더링하는 컴포넌트
+export const Icon = ({ name, ...props }: IconProps) => {
+  switch (name) {
+    case 'pin':
+      return <Pin {...props} />;
+    case 'trash':
+      return <Trash2 {...props} />;
+    case 'edit':
+      return <Pencil {...props} />;
+    case 'check':
+      return <CheckCircle2 {...props} />;
+    case 'circle':
+      return <Circle {...props} />;
+    case 'more':
+      return <MoreHorizontal {...props} />;
+    case 'more-vertical':
+      return <EllipsisVertical {...props} />;
+    default:
+      return null; // 정의되지 않은 이름일 경우 아무것도 렌더링하지 않음
+  }
+};

--- a/src/components/atoms/Icon/index.ts
+++ b/src/components/atoms/Icon/index.ts
@@ -1,0 +1,1 @@
+export * from './Icon';

--- a/src/components/ui/button.stories.tsx
+++ b/src/components/ui/button.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Button } from './button';
+
+const meta = {
+  title: 'Components/Atoms/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
+      description: '버튼의 시각적 스타일을 결정합니다.',
+    },
+    size: {
+      control: 'select',
+      options: ['default', 'sm', 'lg', 'icon'],
+      description: '버튼의 크기를 결정합니다.',
+    },
+    asChild: {
+      control: 'boolean',
+      description: '버튼을 자식 컴포넌트로 렌더링할지 여부를 결정합니다.',
+    },
+    children: {
+      control: 'text',
+      description: '버튼 내부에 표시될 내용입니다.',
+    },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    variant: 'default',
+    size: 'default',
+    children: 'Default Button',
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    variant: 'destructive',
+    size: 'default',
+    children: 'Destructive Button',
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    variant: 'outline',
+    size: 'default',
+    children: 'Outline Button',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+    size: 'default',
+    children: 'Secondary Button',
+  },
+};
+
+export const Ghost: Story = {
+  args: {
+    variant: 'ghost',
+    size: 'default',
+    children: 'Ghost Button',
+  },
+};
+
+export const Link: Story = {
+  args: {
+    variant: 'link',
+    size: 'default',
+    children: 'Link Button',
+  },
+};

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline:
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+        secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<'button'> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot : 'button';
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/src/components/ui/input.stories.tsx
+++ b/src/components/ui/input.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Input } from './input';
+
+const meta = {
+  title: 'Components/Atoms/Input',
+  component: Input,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'select',
+      options: ['text', 'password', 'email', 'number'],
+      description: '입력 필드의 타입을 선택합니다.',
+    },
+    placeholder: {
+      control: 'text',
+      description: '입력 필드에 표시될 안내 텍스트입니다.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: '입력 필드를 비활성화합니다.',
+    },
+    value: {
+      control: 'text',
+      description: '입력 필드의 현재 값입니다 (제어 컴포넌트용).',
+    },
+  },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * **Default Input**
+ *
+ * 가장 기본적인 형태의 입력 필드입니다.
+ */
+export const Default: Story = {
+  args: {
+    type: 'text',
+    placeholder: '이메일을 입력하세요...',
+  },
+};
+
+/**
+ * **Password Input**
+ *
+ * `type`을 'password'로 설정하여, 입력된 내용이 가려지도록 합니다.
+ */
+export const Password: Story = {
+  args: {
+    type: 'password',
+    placeholder: '비밀번호',
+  },
+};
+
+/**
+ * **Disabled Input**
+ *
+ * `disabled` prop을 true로 설정하여, 입력을 비활성화한 상태입니다.
+ */
+export const Disabled: Story = {
+  args: {
+    type: 'text',
+    placeholder: '입력할 수 없습니다',
+    disabled: true,
+  },
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };


### PR DESCRIPTION
## 📖 스토리북 링크 (Storybook Link)

> 변경된 UI 컴포넌트를 시각적으로 확인하고 인터랙션해볼 수 있는 스토리북 링크를 첨부합니다.

---

## 🔗 관련 이슈 번호 (Related Issue Number)

> 이 Pull Request가 해결하고자 하는 이슈의 번호를 기재합니다. 이슈 연결을 통해 작업의 배경과 목적을 쉽게 파악할 수 있습니다. (예: Closes #123)

- Closes #12 

---

## ✨ PR 세부 내용 (PR Details)

> 이번 PR에서 어떤 작업을 했는지 상세하게 설명합니다. 코드 변경의 이유, 구현 방식, 주요 로직 등을 중심으로 작성하면 리뷰어가 이해하는 데 도움이 됩니다.

**작업 개요**
아토믹 디자인(Atomic Design) 기반의 컴포넌트 폴더 구조 예시를 위해 기본 atoms 컴포넌트를 구현했습니다.

**주요 변경사항**
- 컴포넌트 신규 개발 (atom): atoms 폴더내의 예시를 위해 lucide-react 아이콘을 name prop으로 손쉽게 호출할 수 있는 표준 Icon 컴포넌트를 추가했습니다.
- Shadcn 컴포넌트 설치: button, input

**기술적 구현 사항**

---

## 📸 참고할 스크린샷/영상 (Screenshots/Videos)

> 작업 내용과 관련된 시각적인 자료가 있다면 첨부합니다. UI 변경이나 새로운 기능의 동작 방식을 보여주는 스크린샷 또는 영상을 활용하면 리뷰어의 이해를 돕습니다.

**스크린샷**
참고용 폴더 구조
![image](https://github.com/user-attachments/assets/53f5f2eb-8a18-4858-a657-43ec7e244e69)

**기능 동작 영상**

**추가 참고 자료**
