### PR TITLE
[Feat/#50] 공통 컴포넌트 modal 제작

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+import { createPortal } from 'react-dom';
+
+import { cn } from '@/lib/utils';
+
+const modalOverlayVariants = cva(
+  'fixed inset-0 flex items-center justify-center transition-opacity duration-300',
+  {
+    variants: {
+      overlay: {
+        default: 'bg-black/50',
+        dark: 'bg-black/70',
+        light: 'bg-black/30',
+      },
+      layer: {
+        base: '',
+        stacked: 'z-60',
+      },
+    },
+    defaultVariants: {
+      overlay: 'default',
+    },
+  },
+);
+
+const modalContentVariants = cva(
+  'relative scale-100 transform rounded-3xl bg-white shadow-2xl transition-all duration-300',
+  {
+    variants: {
+      size: {
+        goal: 'h-552 w-600',
+        todo: 'h-auto w-600',
+        link: 'h-auto w-520',
+      },
+      padding: {
+        default: 'p-40',
+      },
+      margin: {
+        default: 'm-16',
+      },
+      rounded: {
+        default: 'rounded-3xl',
+        none: 'rounded-none',
+      },
+      animation: {
+        none: '',
+      },
+    },
+    defaultVariants: {
+      size: 'todo',
+      padding: 'default',
+      margin: 'default',
+      rounded: 'default',
+      animation: 'none',
+    },
+  },
+);
+
+export interface ModalProps extends VariantProps<typeof modalContentVariants> {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  overlay?: VariantProps<typeof modalOverlayVariants>['overlay'];
+  layer?: VariantProps<typeof modalOverlayVariants>['layer'];
+  closeOnOverlayClick?: boolean;
+  closeOnEscape?: boolean;
+  className?: string;
+}
+
+const Modal = ({
+  isOpen,
+  onClose,
+  children,
+  size,
+  padding,
+  margin,
+  rounded,
+  animation,
+  overlay = 'default',
+  layer = 'base',
+  closeOnOverlayClick = true,
+  closeOnEscape = true,
+  className,
+}: ModalProps) => {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen]);
+
+  // ESC 키 처리
+  useEffect(() => {
+    if (!isOpen || !closeOnEscape) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, closeOnEscape, onClose]);
+
+  if (!mounted || !isOpen) return null;
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget && closeOnOverlayClick) {
+      onClose();
+    }
+  };
+
+  return createPortal(
+    <div className={modalOverlayVariants({ overlay, layer })} onClick={handleOverlayClick}>
+      <div
+        className={cn(
+          modalContentVariants({
+            size,
+            padding,
+            margin,
+            rounded,
+            animation,
+          }),
+          className,
+        )}
+        onClick={e => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+export default Modal;

--- a/src/stories/ui/Modal.stories.tsx
+++ b/src/stories/ui/Modal.stories.tsx
@@ -1,0 +1,164 @@
+import React, { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import Modal from '@/components/ui/Modal';
+
+const meta: Meta<typeof Modal> = {
+  title: 'Components/ui/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: ['goal', 'todo', 'link'],
+    },
+    overlay: {
+      control: { type: 'select' },
+      options: ['default', 'dark', 'light'],
+    },
+    layer: {
+      control: { type: 'select' },
+      options: ['base', 'stacked'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Modal>;
+
+const ModalWithHooks = (args: any) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        className="rounded-lg bg-blue-500 px-16 py-8 text-white hover:bg-blue-600"
+      >
+        모달 열기
+      </button>
+      <Modal {...args} isOpen={isOpen} onClose={() => setIsOpen(false)}>
+        {args.children}
+      </Modal>
+    </>
+  );
+};
+
+export const Default: Story = {
+  render: ModalWithHooks,
+  args: {
+    size: 'todo',
+    children: (
+      <div>
+        <h2 className="mb-4 text-xl font-bold">기본 모달</h2>
+        <p className="mb-6 text-gray-600">기본 스타일의 모달입니다.</p>
+        <button className="rounded bg-blue-500 px-4 py-2 text-white">확인</button>
+      </div>
+    ),
+  },
+};
+
+export const GoalModal: Story = {
+  render: ModalWithHooks,
+  args: {
+    size: 'goal',
+    children: (
+      <div>
+        <h2 className="mb-6 text-xl font-bold">🎯 목표 생성</h2>
+        <div className="space-y-4">
+          <input
+            type="text"
+            placeholder="목표의 이름을 적어주세요"
+            className="w-full rounded-lg border px-3 py-2"
+          />
+          <input type="date" className="w-full rounded-lg border px-3 py-2" />
+        </div>
+        <button className="mt-6 w-full rounded-lg bg-blue-500 py-3 text-white">생성하기</button>
+      </div>
+    ),
+  },
+};
+
+export const LinkModal: Story = {
+  render: ModalWithHooks,
+  args: {
+    size: 'link',
+    layer: 'stacked',
+    children: (
+      <div>
+        <h2 className="mb-6 text-xl font-bold">🔗 링크 업로드</h2>
+        <input
+          type="url"
+          placeholder="www.example.com"
+          className="mb-6 w-full rounded-lg border px-3 py-2"
+        />
+        <div className="flex gap-3">
+          <button className="flex-1 rounded-lg bg-gray-200 py-2">취소</button>
+          <button className="flex-1 rounded-lg bg-blue-500 py-2 text-white">확인</button>
+        </div>
+      </div>
+    ),
+  },
+};
+
+export const DarkOverlay: Story = {
+  render: ModalWithHooks,
+  args: {
+    size: 'todo',
+    overlay: 'dark',
+    children: (
+      <div className="text-center">
+        <h2 className="mb-4 text-xl font-bold">어두운 오버레이</h2>
+        <p className="text-gray-600">배경이 더 어둡게 표시됩니다.</p>
+      </div>
+    ),
+  },
+};
+
+export const StackedModal: Story = {
+  render: () => {
+    const [firstOpen, setFirstOpen] = useState(false);
+    const [secondOpen, setSecondOpen] = useState(false);
+
+    return (
+      <>
+        <button
+          onClick={() => setFirstOpen(true)}
+          className="rounded bg-blue-500 px-4 py-2 text-white"
+        >
+          첫 번째 모달 열기
+        </button>
+
+        <Modal isOpen={firstOpen} onClose={() => setFirstOpen(false)} size="todo">
+          <div>
+            <h2 className="mb-4 text-xl font-bold">첫 번째 모달</h2>
+            <button
+              onClick={() => setSecondOpen(true)}
+              className="mr-2 rounded bg-green-500 px-4 py-2 text-white"
+            >
+              두 번째 모달 열기
+            </button>
+          </div>
+        </Modal>
+
+        <Modal isOpen={secondOpen} onClose={() => setSecondOpen(false)} size="link" layer="stacked">
+          <div>
+            <h2 className="mb-4 text-xl font-bold">두 번째 모달</h2>
+            <p className="mb-4">스택된 모달입니다.</p>
+            <button
+              onClick={() => setSecondOpen(false)}
+              className="rounded bg-blue-500 px-4 py-2 text-white"
+            >
+              닫기
+            </button>
+          </div>
+        </Modal>
+      </>
+    );
+  },
+};


### PR DESCRIPTION
## 📖 스토리북 링크 (Storybook Link)

> 변경된 UI 컴포넌트를 시각적으로 확인하고 인터랙션해볼 수 있는 스토리북 링크를 첨부합니다.

- [바로가기]()

---

## 🔗 관련 이슈 번호 (Related Issue Number)

> 이 Pull Request가 해결하고자 하는 이슈의 번호를 기재합니다. 이슈 연결을 통해 작업의 배경과 목적을 쉽게 파악할 수 있습니다. (예: Closes #123)

- Closes #50 

---

## ✨ PR 세부 내용 (PR Details)

> 이번 PR에서 어떤 작업을 했는지 상세하게 설명합니다. 코드 변경의 이유, 구현 방식, 주요 로직 등을 중심으로 작성하면 리뷰어가 이해하는 데 도움이 됩니다.

**작업 개요**
애플리케이션 전반의 재사용성 높이기 위해 공통 모달(Modal)을 개발했습니다

**주요 변경사항**
- Modal 컴포넌트 추가

**기술적 구현 사항**
- 외부 클릭 닫기: 모달 외부의 어두운 배경(Overlay)이나 닫기(X) 버튼 클릭 시 모달이 닫히는 기능이 포함되었습니다.
- ESC 키로 닫기할 수 있도록 구현했습니다.
- React Portal을 사용하여 불필요한 CSS 충돌을 방지하고 DOM 구조를 깔끔하게 유지합니다.
---

## 📸 참고할 스크린샷/영상 (Screenshots/Videos)

> 작업 내용과 관련된 시각적인 자료가 있다면 첨부합니다. UI 변경이나 새로운 기능의 동작 방식을 보여주는 스크린샷 또는 영상을 활용하면 리뷰어의 이해를 돕습니다.

**UI 변경 전/후 스크린샷**

**기능 동작 영상**

**추가 참고 자료**
