### PR TITLE
[Refactor/#129] 캘린더 백엔드 API 연동 및 데이터 매퍼 구현

### DIFF
--- a/src/api/calendarApi.ts
+++ b/src/api/calendarApi.ts
@@ -1,9 +1,11 @@
 import { getRequest } from '@/api';
-import { CalendarResponse } from '@/interfaces/calendar';
+import { ApiCalendarResponse, CalendarResponse } from '@/interfaces/calendar';
+import { mapApiResponseToCalendar } from '@/lib/calendarMapper';
 
 export const getCalendarData = async (userId: number, date: string): Promise<CalendarResponse> => {
-  return getRequest('/goals/todos/due-monthly', {
+  const apiResponse: ApiCalendarResponse = await getRequest('/goals/todos/due-monthly', {
     userId,
     date,
   });
+  return mapApiResponseToCalendar(apiResponse);
 };

--- a/src/api/calendarApi.ts
+++ b/src/api/calendarApi.ts
@@ -1,6 +1,9 @@
 import { getRequest } from '@/api';
 import { CalendarResponse } from '@/interfaces/calendar';
 
-export const getCalendarData = async (month: string): Promise<CalendarResponse> => {
-  return getRequest('/calendar', { month });
+export const getCalendarData = async (userId: number, date: string): Promise<CalendarResponse> => {
+  return getRequest('/goals/todos/due-monthly', {
+    userId,
+    date,
+  });
 };

--- a/src/hooks/useGoalCalendar.ts
+++ b/src/hooks/useGoalCalendar.ts
@@ -5,12 +5,12 @@ import { useQuery } from '@tanstack/react-query';
 import { getCalendarData } from '@/api/calendarApi';
 import { CalendarData, CalendarResponse } from '@/interfaces/calendar';
 import { getCalendarInfo, groupGoalsByDate } from '@/lib/calendar';
+import { useUserStore } from '@/store/userStore';
 
 // 캘린더 렌더링에 필요한 데이터를 계산
 export const useCalendarData = (data: CalendarData) => {
   return useMemo(() => {
     const { month, goals } = data;
-
     const { currentMonth, firstDay, daysInMonth } = getCalendarInfo(month);
     const groupedGoals = groupGoalsByDate(goals);
 
@@ -23,9 +23,12 @@ export const useCalendarData = (data: CalendarData) => {
   }, [data]);
 };
 
-export const useDeadlineCalendar = (month: string) => {
+export const useDeadlineCalendar = (date: string) => {
+  const user = useUserStore(state => state.user);
+
   return useQuery<CalendarResponse>({
-    queryKey: ['calendar', month],
-    queryFn: () => getCalendarData(month),
+    queryKey: ['calendar', user?.id, date],
+    queryFn: () => getCalendarData(user!.id, date),
+    enabled: !!user?.id,
   });
 };

--- a/src/interfaces/calendar.ts
+++ b/src/interfaces/calendar.ts
@@ -17,3 +17,17 @@ export interface CalendarResponse {
 }
 
 export const DAYS = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+// API 명세서 기반 응답 타입
+export interface ApiGoal {
+  id: string;
+  name: string;
+  color: string;
+  createdDateTime: string;
+  dueDateTime: string;
+}
+
+export interface ApiCalendarResponse {
+  date: string;
+  goals: ApiGoal[];
+}

--- a/src/lib/calendarMapper.ts
+++ b/src/lib/calendarMapper.ts
@@ -1,0 +1,19 @@
+import { ApiCalendarResponse, CalendarResponse, Goal } from '@/interfaces/calendar';
+
+export const mapApiResponseToCalendar = (apiResponse: ApiCalendarResponse): CalendarResponse => {
+  const mappedGoals: Goal[] = apiResponse.goals.map(apiGoal => ({
+    id: apiGoal.id,
+    title: apiGoal.name,
+    due_date: apiGoal.dueDateTime,
+    color: apiGoal.color,
+    created_at: apiGoal.createdDateTime,
+  }));
+
+  return {
+    success: true,
+    data: {
+      month: apiResponse.date,
+      goals: mappedGoals,
+    },
+  };
+};

--- a/src/mocks/handlers/calendarHandlers.ts
+++ b/src/mocks/handlers/calendarHandlers.ts
@@ -7,7 +7,7 @@ import {
 } from '@/mocks/mockResponses/calendar/calendarResponse';
 
 export const calendarHandlers = [
-  http.get('/calendar', ({ request }) => {
+  http.get('/goals/todos/due-monthly', ({ request }) => {
     const url = new URL(request.url);
     const month = url.searchParams.get('month');
 


### PR DESCRIPTION
## 🔗 관련 이슈 번호 (Related Issue Number)

> 이 Pull Request가 해결하고자 하는 이슈의 번호를 기재합니다. 이슈 연결을 통해 작업의 배경과 목적을 쉽게 파악할 수 있습니다. (예: Closes #123)

- Closes #129

---

## ✨ PR 세부 내용 (PR Details)

> 이번 PR에서 어떤 작업을 했는지 상세하게 설명합니다. 코드 변경의 이유, 구현 방식, 주요 로직 등을 중심으로 작성하면 리뷰어가 이해하는 데 도움이 됩니다.

**작업 개요**
- 캘린더 컴포넌트를 실제 백엔드 API(`/goals/todos/due-monthly`)와 연동
- API 응답 데이터를 프론트엔드 인터페이스에 맞게 변환하는 매퍼 시스템 구현

**주요 변경사항**
- API 엔드포인트 업데이트: `/calendar` → `/goals/todos/due-monthly`
- 파라미터 변경: `month` → `userId`, `date`
- 데이터 매핑 시스템 구현: 백엔드 응답을 프론트엔드 형식으로 변환
- 사용자 인증 연동: `useUserStore`에서 사용자 정보 가져와서 API 호출

**기술적 구현 사항**
