### PR TITLE
[Fix/#157] 유저 & 인증 전역 상태 관리에 대해서 수정한다.

### DIFF
--- a/src/api/apiWrapper.ts
+++ b/src/api/apiWrapper.ts
@@ -33,7 +33,6 @@ export async function fetchWrapper(url: string, options: RequestInit = {}) {
     const isLoginRequest = url.includes('/auths/signIn');
 
     if (isLoginRequest) {
-      console.log(headers);
       const tokenHeader = response.headers.get('Authorization');
       const token = tokenHeader?.startsWith('Bearer ') ? tokenHeader.split(' ')[1] : null;
 

--- a/src/api/apiWrapper.ts
+++ b/src/api/apiWrapper.ts
@@ -1,5 +1,8 @@
+'use client';
+
 import { RequestInit } from 'next/dist/server/web/spec-extension/request';
 
+import { ROUTES } from '@/lib/routes';
 import { useAuthStore } from '@/store/authStore';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
@@ -52,6 +55,8 @@ export async function fetchWrapper(url: string, options: RequestInit = {}) {
         });
 
         if (!refreshResponse.ok) {
+          useAuthStore.getState().clearTokens();
+          window.location.href = ROUTES.AUTH.LOGIN;
           throw new CustomError('Failed to refresh token', await refreshResponse.json());
         }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,7 @@
 import { fetchWrapper } from './apiWrapper';
 
+//TODO: 현재 이 컴포넌트는 클라이언트 컴포넌트이기 때문에 서버 컴포넌트에 api 호출하면 에러가 납니다!
+
 type Params = {
   [key: string]: string | number | undefined;
 };

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import z from 'zod';
 
 import useLogin from '@/hooks/auth/useLogin';
+import { useUser } from '@/hooks/auth/useUser';
 import { loginSchema } from '@/interfaces/auth';
+import { useUserStore } from '@/store/userStore';
 
 import { Button } from '../ui/Button';
 
@@ -19,6 +21,7 @@ export type LoginFormData = z.infer<typeof loginSchema>;
 
 export default function LoginForm() {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const setUser = useUserStore(state => state.setUser);
 
   const handleCloseModal = () => setIsModalOpen(false);
 
@@ -45,6 +48,16 @@ export default function LoginForm() {
     setIsModalOpen(false);
     login.mutate(formData);
   };
+
+  const { data } = useUser({
+    enabled: login.isSuccess,
+  });
+
+  useEffect(() => {
+    if (data) {
+      setUser(data);
+    }
+  }, [data, setUser]);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-20 sm:gap-12 md:gap-20">

--- a/src/components/sidebar/SidebarUser.tsx
+++ b/src/components/sidebar/SidebarUser.tsx
@@ -1,21 +1,11 @@
 'use client';
 
-import { useEffect } from 'react';
-
 import { useLogout } from '@/hooks/auth/useLogout';
-import { useUser } from '@/hooks/auth/useUser';
 import { useUserStore } from '@/store/userStore';
 
 export default function SidebarUser() {
-  const { user, setUser } = useUserStore();
+  const user = useUserStore(state => state.user);
   const logout = useLogout();
-  const { data } = useUser();
-
-  useEffect(() => {
-    if (data) {
-      setUser(data);
-    }
-  }, [data, setUser]);
 
   return (
     <div className="flex flex-col gap-12">

--- a/src/hooks/auth/useUser.ts
+++ b/src/hooks/auth/useUser.ts
@@ -3,10 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 import { getUser } from '@/api/authApi';
 import { User, UserResponse } from '@/interfaces/auth';
 
-export const useUser = () => {
+export const useUser = ({ enabled = true }) => {
   return useQuery({
     queryKey: ['user'],
     queryFn: getUser,
+    enabled,
     select: (data: UserResponse): User => ({
       id: data.result.id,
       email: data.result.email,

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 interface AuthState {
   accessToken: string | null;
@@ -6,8 +7,16 @@ interface AuthState {
   clearTokens: () => void;
 }
 
-export const useAuthStore = create<AuthState>(set => ({
-  accessToken: null,
-  setAccessToken: token => set({ accessToken: token }),
-  clearTokens: () => set({ accessToken: null }),
-}));
+export const useAuthStore = create<AuthState>()(
+  persist(
+    set => ({
+      accessToken: null,
+      setAccessToken: token => set({ accessToken: token }),
+      clearTokens: () => set({ accessToken: null }),
+    }),
+    {
+      name: 'auth-storage',
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+);

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 import type { User } from '@/interfaces/auth';
 
@@ -7,7 +8,15 @@ interface UserState {
   setUser: (_user: User | null) => void;
 }
 
-export const useUserStore = create<UserState>(set => ({
-  user: null,
-  setUser: newUser => set({ user: newUser }),
-}));
+export const useUserStore = create<UserState>()(
+  persist(
+    set => ({
+      user: null,
+      setUser: newUser => set({ user: newUser }),
+    }),
+    {
+      name: 'user-storage',
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+);


### PR DESCRIPTION
## 🔗 관련 이슈 번호 (Related Issue Number)

- Closes #157 

---

## ✨ PR 세부 내용 (PR Details)

**작업 개요**

- user & auth store의 상태값에 persist sessionStorage 적용
- sidebar에서 호출하던 유저의 정보를 로그인 할 때 호출해서 user 전역 상태로 저장

**주요 변경사항**

- 

**기술적 구현 사항**

- user & auth store에 persist 적용

---