### PR TITLE
[Style/#180] 랜딩페이지 반응형 디자인을 적용

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ export default function Home() {
         <LandingBanner />
       </section>
 
-      <section className="mb-240">
+      <section className="sm:mb-100 md:mb-200 lg:mb-240">
         <LandingIntroduction />
       </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import LandingIntroduction from '@/components/landing/LandingIntroduction';
 export default function Home() {
   return (
     <>
-      <section className="mb-200">
+      <section className="mb-200 sm:mb-140 md:mb-200">
         <LandingBanner />
       </section>
 

--- a/src/components/landing/LandingBanner.tsx
+++ b/src/components/landing/LandingBanner.tsx
@@ -43,29 +43,36 @@ export default function LandingBanner() {
   }, []);
 
   return (
-    <div className="bg-primary-01 flex h-620 items-center justify-center gap-189">
+    <div className="bg-primary-01 flex h-620 items-center sm:flex-col sm:justify-center sm:gap-30 md:flex-row md:justify-between md:gap-30 md:pl-32 lg:justify-center lg:gap-140">
       <div
         ref={btnRef}
-        className={cn('flex transform flex-col gap-42 transition-all duration-1000 ease-out', {
-          'translate-x-0 opacity-100': btnInView,
-          '-translate-x-10 opacity-0': !btnInView,
-        })}
+        className={cn(
+          'flex transform flex-col transition-all duration-1000 ease-out sm:gap-24 md:gap-32 lg:gap-42',
+          {
+            'translate-x-0 opacity-100': btnInView,
+            '-translate-x-10 opacity-0': !btnInView,
+          },
+        )}
       >
-        <div className="bg-text-01 p-6.67 rounded-12 flex h-80 w-80 items-center justify-center">
-          <Image src="/assets/images/logoIcon.svg" alt="로고 아이콘" width={66.67} height={66.67} />
+        <div className="bg-text-01 p-6.67 rounded-12 flex items-center justify-center sm:h-40 sm:w-40 md:h-40 md:w-40 lg:h-80 lg:w-80">
+          <div className="relative sm:h-33 sm:w-33 md:h-33 md:w-33 lg:h-67 lg:w-67">
+            <Image src="/assets/images/logoIcon.svg" alt="로고 아이콘" fill />
+          </div>
         </div>
-        <div className="mb-10">
-          <span className="text-banner-44 text-white">
+        <div className="sm:mb-0 md:mb-0 lg:mb-10">
+          <span className="lg:text-banner-44 md:text-banner-24 sm:text-banner-24 flex text-white sm:flex-col md:flex-col lg:block">
             목표 중심의
-            <br /> 스마트한 생산성 관리, <span className="text-banner-44-bold">FlowIt</span>
+            <br /> 스마트한 생산성 관리,{' '}
+            <span className="lg:text-banner-44-bold md:text-logo-32 sm:text-logo-32">FlowIt</span>
           </span>
         </div>
-        <div className="flex gap-20">
+        <div className="flex sm:gap-12 md:gap-12 lg:gap-20">
           <Button
             variant="secondary"
             text="secondary"
             disabled={false}
             onClick={() => router.push(ROUTES.AUTH.LOGIN)}
+            className="sm:h-44 sm:w-118 md:h-44 md:w-118 lg:h-62 lg:w-240"
           >
             로그인
           </Button>
@@ -74,6 +81,7 @@ export default function LandingBanner() {
             text="secondary"
             disabled={false}
             onClick={() => router.push(ROUTES.AUTH.SIGNUP)}
+            className="sm:h-44 sm:w-118 md:h-44 md:w-118 lg:h-62 lg:w-240"
           >
             회원가입
           </Button>
@@ -90,14 +98,10 @@ export default function LandingBanner() {
           },
         )}
       >
-        <div className="rounded-tl-50 rounded-bl-50 bg-landing-blue absolute h-343 w-850 -translate-x-[2%]" />
-        <Image
-          src="/assets/images/dashboard.svg"
-          alt="대쉬보드 이미지"
-          width={699.78}
-          height={399.88}
-          className="relative z-10"
-        />
+        <div className="rounded-tl-50 rounded-bl-50 bg-landing-blue absolute sm:hidden md:block md:h-240 md:w-400 md:-translate-x-[5%] lg:block lg:h-343 lg:w-1045 lg:translate-x-[8%]" />
+        <div className="relative z-10 sm:h-194 sm:w-340 md:h-206 md:w-361 lg:h-400 lg:w-700">
+          <Image src="/assets/images/dashboard.svg" alt="대쉬보드 이미지" fill />
+        </div>
       </div>
     </div>
   );

--- a/src/components/landing/LandingFeaturesDetail.tsx
+++ b/src/components/landing/LandingFeaturesDetail.tsx
@@ -42,7 +42,7 @@ export default function LandingFeaturesDetail() {
   }, []);
 
   return (
-    <div className="flex flex-col items-center gap-240">
+    <div className="flex flex-col items-center sm:gap-100 md:gap-160 lg:gap-240">
       {LANDINGPAGEFEATUREDETAILS.map((detail, index) => {
         const isOdd = index % 2 === 1;
         const isVisible = visibleIndexes.includes(index);
@@ -55,10 +55,10 @@ export default function LandingFeaturesDetail() {
               containerRefs.current[index] = el;
             }}
             className={cn(
-              `flex transform gap-120 transition-all duration-700 ease-out ${delayClasses[index % delayClasses.length]}`,
+              `flex transform transition-all duration-700 ease-out sm:flex-col sm:gap-40 md:flex-col md:gap-64 lg:flex-row lg:gap-120 ${delayClasses[index % delayClasses.length]}`,
               {
-                'ml-124 flex-row-reverse': isOdd,
-                'flex-row': !isOdd,
+                'lg:ml-124 lg:flex-row-reverse': isOdd,
+                'lg:flex-row': !isOdd,
               },
               {
                 'translate-y-0 opacity-100': isVisible,
@@ -66,10 +66,14 @@ export default function LandingFeaturesDetail() {
               },
             )}
           >
-            <Image src={detail.imgUrl} alt={detail.name} width={700} height={700} />
-            <div className="mt-80 flex flex-col gap-40">
-              <span className="text-banner-44-bold text-text-01">{detail.name}</span>
-              <div className="text-text-03 text-display-24 flex flex-col gap-24">
+            <div className="relative sm:h-263 sm:w-338 md:h-525 md:w-525 lg:h-700 lg:w-700">
+              <Image src={detail.imgUrl} alt={detail.name} fill />
+            </div>
+            <div className="flex flex-col gap-40 sm:mt-0 sm:gap-24 md:mt-0 md:gap-40 lg:mt-80">
+              <span className="text-banner-44-bold md:text-banner-44-bold sm:text-display-24 text-text-01">
+                {detail.name}
+              </span>
+              <div className="text-text-03 text-display-24 md:text-display-24 sm:text-body-b-16 flex flex-col gap-24 sm:gap-12 md:gap-24">
                 {detail.contents.map(content => (
                   <span key={content.name}>{content.name}</span>
                 ))}

--- a/src/components/landing/LandingIntroduction.tsx
+++ b/src/components/landing/LandingIntroduction.tsx
@@ -27,39 +27,44 @@ export default function LandingIntroduction() {
   }, []);
 
   return (
-    <div className="flex flex-col items-center gap-96">
-      <div className="flex flex-col items-center gap-36">
-        <Image
-          src="/assets/images/landing_img.svg"
-          alt="랜딩페이지 이미지"
-          width={360}
-          height={360}
-        />
-        <div className="text-banner-44-bold text-text-01 text-center leading-52">
+    <div className="flex flex-col items-center sm:gap-100 md:gap-90 lg:gap-97">
+      <div className="flex flex-col items-center sm:gap-24 md:gap-36 lg:gap-36">
+        <div className="relative sm:h-200 sm:w-200 md:h-280 md:w-280 lg:h-360 lg:w-360">
+          <Image src="/assets/images/landing_img.svg" alt="랜딩페이지 이미지" fill />
+        </div>
+        <div className="lg:text-banner-44-bold md:text-display-32 sm:text-display-24 text-text-01 text-center lg:leading-52">
           <span className="text-primary-01">목표</span>를 체계적으로
           <br /> 관리하고 성취하는 법
         </div>
-        <span className="text-text-02 text-display-24">
-          FlowIt은 작업 패턴 분석을 통해 개인의 생산성을 극대화하는 서비스 입니다.
-        </span>
+        <div className="text-text-02 lg:text-display-24 md:text-body-sb-20 sm:text-body-m-16 flex text-center sm:flex-col md:flex-row">
+          <span className="sm:mr-0 md:mr-0 lg:mr-8">FlowIt은 작업 패턴 분석을 통해 </span>
+          <span>개인의 생산성을 극대화하는 서비스 입니다.</span>
+        </div>
       </div>
 
-      <div ref={containerRef} className="flex items-center gap-20">
+      <div
+        ref={containerRef}
+        className="md:grid-row-2 sm:grid-row-2 items-center gap-20 sm:grid sm:grid-cols-2 sm:gap-4 md:grid md:grid-cols-2 md:gap-20 lg:flex"
+      >
         {LANDINGPAGEFEATURES.map((feature, index) => {
           const delayClasses = ['delay-0', 'delay-150', 'delay-300', 'delay-450'];
           return (
             <div
               key={feature.name}
               className={cn(
-                `rounded-20 flex h-360 w-325 flex-col items-center justify-center gap-36 ${feature.bgColor} ${delayClasses[index]} transform transition-all duration-700 ease-out`,
+                `rounded-20 flex h-360 w-325 flex-col items-center justify-center gap-36 sm:h-190 sm:w-172 sm:gap-12 md:h-360 md:w-325 md:gap-36 ${feature.bgColor} ${delayClasses[index]} transform transition-all duration-700 ease-out`,
                 {
                   'translate-y-0 opacity-100': inView,
                   'translate-y-30 opacity-0': !inView,
                 },
               )}
             >
-              <Image src={feature.imgUrl} alt={feature.name} width={200} height={200} />
-              <span className="text-text-02 text-display-24">{feature.name}</span>
+              <div className="relative h-200 w-200 sm:h-100 sm:w-100 md:h-200 md:w-200">
+                <Image src={feature.imgUrl} alt={feature.name} fill />
+              </div>
+              <span className="text-text-02 text-display-24 md:text-display-24 sm:text-body-m-16">
+                {feature.name}
+              </span>
             </div>
           );
         })}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -271,6 +271,11 @@
   font-weight: 700;
 }
 
+@utility text-logo-32 {
+  font-size: 32px;
+  font-weight: 700;
+}
+
 @utility text-logo-24 {
   font-size: 24px;
   font-weight: 500;
@@ -284,6 +289,11 @@
 @utility text-banner-44-bold {
   font-size: 44px;
   font-weight: 700;
+}
+
+@utility text-banner-24 {
+  font-size: 24px;
+  font-weight: 500;
 }
 
 /* ========================================================================


### PR DESCRIPTION
## 🔗 관련 이슈 번호 (Related Issue Number)

- Closes #180 

---

## ✨ PR 세부 내용 (PR Details)

**작업 개요**

- 랜딩페이지 tablet, mobile 사이즈에 대한 반응형 사이즈 구현

**주요 변경사항**

- LandingBanner.tsx
- LandingIntroduction.tsx
- LandingFeaturesDetail.tsx

---

## 📸 참고할 스크린샷/영상 (Screenshots/Videos)

**UI 스크린샷**

- tablet
<img width="494" height="745" alt="image" src="https://github.com/user-attachments/assets/ad5a213b-cf38-4424-a5a7-51f6a4d63045" />
<img width="493" height="746" alt="image" src="https://github.com/user-attachments/assets/b69e42d3-d668-4387-b69e-267d85412e2c" />

- mobile
<img width="282" height="749" alt="image" src="https://github.com/user-attachments/assets/dcfef2cf-706b-4dde-95bb-bd5bc73c1acd" />
<img width="279" height="742" alt="image" src="https://github.com/user-attachments/assets/d1036656-ac01-45c4-bd2c-c4e9e3d8c35c" />
