### PR TITLE
[Fix:#220] - refresh token logic을 변경 된 api 응답에 맞게 수정

### DIFF
--- a/src/api/apiWrapper.ts
+++ b/src/api/apiWrapper.ts
@@ -44,9 +44,8 @@ export async function fetchWrapper(
 
     if (!response.ok) {
       if (response.status === 401) {
-        const userId = await getCookie('userId');
-        const refreshToken = await getCookie(`refreshToken_${userId}`);
-        const newAccessToken = await refreshAccessToken(refreshToken, userId);
+        const refreshToken = await getCookie('refreshToken');
+        const newAccessToken = await refreshAccessToken(refreshToken);
 
         if (!newAccessToken) return;
 

--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -12,7 +12,7 @@ export const postLogin = async (email: string, password: string) => {
     const data = await postRequest('/auths/signIn', params);
     const accessToken = data.result.accessToken;
     const refreshToken = data.result.refreshToken;
-    if (refreshToken) await setCookie(`refreshToken_${data.result.id}`, refreshToken);
+    if (refreshToken) await setCookie('refreshToken', refreshToken);
     if (accessToken) await setCookie('accessToken', accessToken);
 
     return { data, accessToken: accessToken };
@@ -55,9 +55,6 @@ export const getEmailCheck = async (email: string) => {
 export const getUser = async () => {
   try {
     const data = await getRequest('/users/me');
-    const userId = data.result.id;
-    await setCookie('userId', userId);
-
     return data;
   } catch (err) {
     console.error('Fetch user error', err);

--- a/src/api/refreshAccessToken.ts
+++ b/src/api/refreshAccessToken.ts
@@ -7,7 +7,6 @@ let refreshPromise: Promise<string | null> | null = null;
 
 export const refreshAccessToken = async (
   refreshToken: string | undefined,
-  userId: string | undefined,
 ): Promise<string | null> => {
   if (!refreshPromise) {
     refreshPromise = (async () => {
@@ -34,7 +33,7 @@ export const refreshAccessToken = async (
 
         if (result?.result.refreshToken) {
           const refreshToken = result?.result.refreshToken;
-          await setCookie(`refreshToken_${userId}`, refreshToken);
+          await setCookie('refreshToken', refreshToken);
         }
 
         return newAccessToken;

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -7,7 +7,7 @@ export async function POST() {
     expires: new Date(0),
   });
 
-  response.cookies.set('userId', '', {
+  response.cookies.set('refreshToken', '', {
     path: '/',
     expires: new Date(0),
   });


### PR DESCRIPTION
## 🔗 관련 이슈 번호 (Related Issue Number)

- Closes #220 

---

## ✨ PR 세부 내용 (PR Details)

**작업 개요**

- userId 서버 쿠키에 저장하는 로직 삭제
- 로그아웃 시 refresh token도 초기화 되도록 설정

---
