### PR TITLE
[Style/#226] 랜딩페이지 반응형 디자인 수정

### DIFF
--- a/src/components/landing/LandingBanner.tsx
+++ b/src/components/landing/LandingBanner.tsx
@@ -45,11 +45,11 @@ export default function LandingBanner() {
   }, []);
 
   return (
-    <div className="bg-primary-01 flex h-620 items-center sm:flex-col sm:justify-center sm:gap-30 md:flex-row md:justify-between md:gap-30 md:pl-32 lg:justify-center lg:gap-140">
+    <div className="bg-primary-01 flex h-620 items-center sm:flex-col sm:justify-center sm:gap-30 md:flex-row md:justify-between md:gap-30 md:pl-32 lg:gap-52">
       <div
         ref={btnRef}
         className={cn(
-          'flex transform flex-col transition-all duration-1000 ease-out sm:gap-24 md:gap-32 lg:gap-42',
+          'flex w-2/3 transform flex-col flex-nowrap transition-all duration-1000 ease-out sm:gap-24 md:gap-32 lg:gap-42',
           {
             'translate-x-0 opacity-100': btnInView,
             '-translate-x-10 opacity-0': !btnInView,
@@ -65,10 +65,12 @@ export default function LandingBanner() {
           />
         </div>
         <div className="sm:mb-0 md:mb-0 lg:mb-10">
-          <span className="lg:text-banner-44 md:text-banner-24 sm:text-banner-24 flex text-white sm:flex-col md:flex-col lg:block">
+          <span className="lg:text-banner-32 xl:text-banner-44 md:text-banner-24 sm:text-banner-24 flex text-white sm:flex-col md:flex-col lg:block">
             목표 중심의
             <br /> 스마트한 생산성 관리,
-            <span className="lg:text-banner-44-bold md:text-logo-32 sm:text-logo-32">FlowIt</span>
+            <span className="lg:text-banner-32-bold xl:text-banner-44-bold md:text-logo-32 sm:text-logo-32">
+              FlowIt
+            </span>
           </span>
         </div>
         <div className="flex sm:gap-12 md:gap-12 lg:gap-20">
@@ -96,22 +98,22 @@ export default function LandingBanner() {
       <div
         ref={imgRef}
         className={cn(
-          'relative flex transform items-center justify-center transition-all duration-1000 ease-out',
+          'relative flex transform items-center transition-all duration-1000 ease-out md:w-full md:max-w-full',
           {
             'translate-x-0 opacity-100': imgInView,
             '-translate-x-10 opacity-0': !imgInView,
           },
         )}
       >
-        <div className="rounded-tl-50 rounded-bl-50 bg-landing-blue absolute h-343 w-850 -translate-x-[2%]" />
-        <Image
-          src={`${CLOUDFRONT_URL}/assets/images/landing_dashboard.svg`}
-          alt="대쉬보드 이미지"
-          width={699.78}
-          height={399.88}
-          className="relative z-10"
-          priority
-        />
+        <div className="rounded-tl-50 rounded-bl-50 bg-landing-blue absolute w-full sm:hidden md:block md:h-240 lg:block lg:h-300 xl:h-343" />
+        <div className="relative z-10 w-full sm:h-194 sm:w-340 md:ml-40 md:h-206 md:w-361 lg:ml-60 lg:h-400 lg:w-full lg:max-w-700 xl:ml-80">
+          <Image
+            src={`${CLOUDFRONT_URL}/assets/images/landing_dashboard.svg`}
+            alt="대쉬보드 이미지"
+            fill
+            priority
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/landing/LandingFeaturesDetail.tsx
+++ b/src/components/landing/LandingFeaturesDetail.tsx
@@ -55,7 +55,7 @@ export default function LandingFeaturesDetail() {
               containerRefs.current[index] = el;
             }}
             className={cn(
-              `flex transform transition-all duration-700 ease-out sm:flex-col sm:gap-40 md:flex-col md:gap-64 lg:flex-row lg:gap-120 ${delayClasses[index % delayClasses.length]}`,
+              `flex transform transition-all duration-700 ease-out sm:flex-col sm:gap-40 md:flex-col md:gap-64 lg:flex-row lg:gap-90 xl:gap-120 ${delayClasses[index % delayClasses.length]}`,
               {
                 'lg:ml-124 lg:flex-row-reverse': isOdd,
                 'lg:flex-row': !isOdd,
@@ -66,14 +66,14 @@ export default function LandingFeaturesDetail() {
               },
             )}
           >
-            <div className="relative sm:h-263 sm:w-338 md:h-525 md:w-525 lg:h-700 lg:w-700">
+            <div className="relative sm:h-263 sm:w-338 md:h-525 md:w-525 lg:h-580 lg:w-580 xl:h-700 xl:w-700">
               <Image src={detail.imgUrl} alt={detail.name} fill />
             </div>
             <div className="flex flex-col gap-40 sm:mt-0 sm:gap-24 md:mt-0 md:gap-40 lg:mt-80">
-              <span className="text-banner-44-bold md:text-banner-44-bold sm:text-display-24 text-text-01">
+              <span className="xl:text-banner-44-bold lg:text-banner-32-bold md:text-banner-44-bold sm:text-display-24 text-text-01">
                 {detail.name}
               </span>
-              <div className="text-text-03 text-display-24 md:text-display-24 sm:text-body-b-16 flex flex-col gap-24 sm:gap-12 md:gap-24">
+              <div className="text-text-03 xl:text-display-24 lg:text-display-18 md:text-display-24 sm:text-body-b-16 flex flex-col gap-24 sm:gap-12 md:gap-24">
                 {detail.contents.map(content => (
                   <span key={content.name}>{content.name}</span>
                 ))}

--- a/src/components/landing/LandingIntroduction.tsx
+++ b/src/components/landing/LandingIntroduction.tsx
@@ -58,17 +58,17 @@ export default function LandingIntroduction() {
             <div
               key={feature.name}
               className={cn(
-                `rounded-20 flex h-360 w-325 flex-col items-center justify-center gap-36 sm:h-190 sm:w-172 sm:gap-12 md:h-360 md:w-325 md:gap-36 ${feature.bgColor} ${delayClasses[index]} transform transition-all duration-700 ease-out`,
+                `rounded-20 flex flex-col items-center justify-center sm:h-190 sm:w-172 sm:gap-12 md:h-360 md:w-325 md:gap-36 lg:h-260 lg:w-225 lg:gap-20 xl:h-340 xl:w-305 xl:gap-36 ${feature.bgColor} ${delayClasses[index]} transform transition-all duration-700 ease-out`,
                 {
                   'translate-y-0 opacity-100': inView,
                   'translate-y-30 opacity-0': !inView,
                 },
               )}
             >
-              <div className="relative h-200 w-200 sm:h-100 sm:w-100 md:h-200 md:w-200">
+              <div className="relative sm:h-100 sm:w-100 md:h-200 md:w-200 lg:h-160 lg:w-160 xl:h-200 xl:w-200">
                 <Image src={feature.imgUrl} alt={feature.name} fill />
               </div>
-              <span className="text-text-02 text-display-24 md:text-display-24 sm:text-body-m-16">
+              <span className="text-text-02 xl:text-display-24 lg:text-display-18 md:text-display-24 sm:text-body-m-16">
                 {feature.name}
               </span>
             </div>

--- a/src/lib/cn.ts
+++ b/src/lib/cn.ts
@@ -7,6 +7,7 @@ const customTwMerge = extendTailwindMerge({
       // Font size group (타이포그래피)
       'font-size': [
         // Title
+        'text-display-18',
         'text-display-32',
         'text-display-24',
         'text-head-20',
@@ -30,6 +31,8 @@ const customTwMerge = extendTailwindMerge({
         'text-logo-32',
         'text-logo-24',
         // Banner
+        'text-banner-32',
+        'text-banner-32-bold',
         'text-banner-44',
         'text-banner-44-bold',
         'text-banner-24',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -253,6 +253,11 @@
   font-weight: 700;
   line-height: 30px;
 }
+@utility text-display-18 {
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 30px;
+}
 @utility text-head-20 {
   font-size: 20px;
   font-weight: 600;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -13,11 +13,10 @@
   --breakpoint-sm: 375px;
   --breakpoint-md: 744px;
   --breakpoint-lg: 1024px;
-
+  --breakpoint-xl: 1337px;
   /* ========================================================================
      Colors (색상)
      ======================================================================== */
-
   /* Base Colors */
   --color-white: #ffffff;
   --color-black: #1e2128;
@@ -349,6 +348,14 @@
 @utility text-banner-44 {
   font-size: 44px;
   font-weight: 500;
+}
+@utility text-banner-32 {
+  font-size: 32px;
+  font-weight: 500;
+}
+@utility text-banner-32-bold {
+  font-size: 32px;
+  font-weight: 700;
 }
 @utility text-banner-44-bold {
   font-size: 44px;


### PR DESCRIPTION
## 🔗 관련 이슈 번호 (Related Issue Number)

- Closes #226 

---

## ✨ PR 세부 내용 (PR Details)

**작업 개요**

- 랜딩페이지 반응형 디자인 수정

*작업 배경**

랜딩페이지 lg 사이즈일 때 1024~1340 px 사이에서 fixed 된 컴포넌트 크기가 너무 커서 반응형이 무너지는 문제가 생겼습니다. 그래서 xl 뷰포트를 하나 더 추가해서 xl 이상일 때 피그마 사이즈 적용되고, lg 이상 xl 이하일 때는 상대적으로 크기를 줄여서 적용했습니다. 

---

