### PR TITLE
[Feat/#249] 목표 개수 표시 및 정렬 기능 추가하여 캘린더 UX 개선

### DIFF
--- a/src/components/calendar/CalendarCell.tsx
+++ b/src/components/calendar/CalendarCell.tsx
@@ -10,9 +10,10 @@ interface CalendarCellProps {
 }
 
 const CalendarCell = ({ date, goals = [], onClick, className }: CalendarCellProps) => {
-  const firstGoal = goals[0];
-  const goalColorName = firstGoal ? getGoalBackgroundColorClass(firstGoal.color) : null;
   const hasGoals = goals.length > 0;
+  const firstGoal = goals[0];
+  const goalName = goals.length === 1 ? firstGoal.title : goals.length;
+  const goalColorName = firstGoal ? getGoalBackgroundColorClass(firstGoal.color) : null;
 
   const handleClick = (event: React.MouseEvent) => {
     if (hasGoals && onClick) {
@@ -31,11 +32,11 @@ const CalendarCell = ({ date, goals = [], onClick, className }: CalendarCellProp
     >
       <span className="text-body-m-16 text-text-03 self-center">{date}</span>
 
-      {firstGoal && (
+      {hasGoals && (
         <div
           className={`text-body-16 rounded-4 ${goalColorName} w-full truncate px-2 text-center text-white`}
         >
-          {firstGoal.title}
+          {goalName}
         </div>
       )}
     </button>

--- a/src/components/calendar/CalendarSection.tsx
+++ b/src/components/calendar/CalendarSection.tsx
@@ -8,7 +8,7 @@ import Card from '@/components/ui/Card';
 import { useDeadlineCalendar } from '@/hooks/useGoalCalendar';
 import usePopover from '@/hooks/usePopover';
 import { Goal } from '@/interfaces/calendar';
-import { getCurrentMonth } from '@/lib/calendar';
+import { getCurrentMonth, sortGoalsByCreatedAt } from '@/lib/calendar';
 
 export default function CalendarSection() {
   const [selectedMonth, setSelectedMonth] = useState(getCurrentMonth());
@@ -57,7 +57,10 @@ export default function CalendarSection() {
     if (goals.length === 0) return;
 
     const target = event.currentTarget as HTMLElement;
-    setSelectedGoals({ date, goals });
+
+    const sortedGoals = sortGoalsByCreatedAt(goals);
+    setSelectedGoals({ date, goals: sortedGoals });
+
     popover.open(target, calendarGridRef.current);
   };
 

--- a/src/components/calendar/CalendarSection.tsx
+++ b/src/components/calendar/CalendarSection.tsx
@@ -8,9 +8,10 @@ import Card from '@/components/ui/Card';
 import { useDeadlineCalendar } from '@/hooks/useGoalCalendar';
 import usePopover from '@/hooks/usePopover';
 import { Goal } from '@/interfaces/calendar';
+import { getCurrentMonth } from '@/lib/calendar';
 
 export default function CalendarSection() {
-  const [selectedMonth, setSelectedMonth] = useState('2025-07');
+  const [selectedMonth, setSelectedMonth] = useState(getCurrentMonth());
   const { data: calendarData } = useDeadlineCalendar(selectedMonth);
 
   const [year, month] = selectedMonth.split('-').map(Number);

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -3,16 +3,16 @@ import dayjs from 'dayjs';
 import { Goal } from '@/interfaces/calendar';
 
 // 목표를 생성일 기준으로 정렬 (최신순)
-export function sortGoalsByCreatedAt(goals: Goal[]): Goal[] {
+export const sortGoalsByCreatedAt = (goals: Goal[]): Goal[] => {
   return [...goals].sort((a, b) => {
     const dateA = new Date(a.created_at);
     const dateB = new Date(b.created_at);
     return dateB.getTime() - dateA.getTime(); // 최신 생성일이 먼저 오도록
   });
-}
+};
 
 // 목표 배열을 날짜별로 그룹핑하고 각 날짜의 목표들을 생성일 기준으로 정렬
-export function groupGoalsByDate(goals: Goal[]): Record<number, Goal[]> {
+export const groupGoalsByDate = (goals: Goal[]): Record<number, Goal[]> => {
   const grouped: Record<number, Goal[]> = {};
 
   if (!Array.isArray(goals)) {
@@ -33,10 +33,10 @@ export function groupGoalsByDate(goals: Goal[]): Record<number, Goal[]> {
   });
 
   return grouped;
-}
+};
 
 // 주어진 월의 캘린더 정보를 계산
-export function getCalendarInfo(month: string) {
+export const getCalendarInfo = (month: string) => {
   const currentMonth = dayjs(month, 'YYYY-MM');
   const firstDay = currentMonth.startOf('month').day(); // 첫 날의 요일 (0: 일요일)
   const daysInMonth = currentMonth.daysInMonth(); // 해당 월의 총 일수
@@ -46,4 +46,12 @@ export function getCalendarInfo(month: string) {
     firstDay,
     daysInMonth,
   };
-}
+};
+
+// 현재 날짜를 YYYY-MM 형태로 반환하는 함수
+export const getCurrentMonth = () => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+};


### PR DESCRIPTION
## 🔗 관련 이슈 번호 (Related Issue Number)

> 이 Pull Request가 해결하고자 하는 이슈의 번호를 기재합니다. 이슈 연결을 통해 작업의 배경과 목적을 쉽게 파악할 수 있습니다. (예: Closes #123)

- Closes #249

---

## ✨ PR 세부 내용 (PR Details)

> 이번 PR에서 어떤 작업을 했는지 상세하게 설명합니다. 코드 변경의 이유, 구현 방식, 주요 로직 등을 중심으로 작성하면 리뷰어가 이해하는 데 도움이 됩니다.

**작업 개요**
- 캘린더 디테일 수정

**주요 변경사항**
- 동적 현재 월 표시: 하드코딩된 날짜(2025-07)를 제거하고 `getCurrentMonth()` 유틸리티를 사용하여 항상 현재 월부터 캘린더가 시작되도록 개선
- 다중 목표 개수 표시: 같은 날짜에 여러 목표가 있을 때 개별 제목 대신 목표 개수(예: "3")를 표시하여 캘린더 가독성 향상
- 팝오버 목표 정렬: 캘린더 팝오버에서 목표들이 생성일 기준 최신순으로 정렬되어 표시되도록 개선