### PR TITLE
[Refactor/#255]  히트맵 컴포넌트 고정 레이아웃 및 빈 상태 처리 구현

### DIFF
--- a/src/components/heatmaps/HeatmapCell.tsx
+++ b/src/components/heatmaps/HeatmapCell.tsx
@@ -15,9 +15,14 @@ const heatmapCellVariants = cva(
         3: 'bg-heatmap-3 text-inactive',
         4: 'bg-heatmap-4 text-inactive border-heatmap-accent border-2',
       },
+      isEmpty: {
+        true: 'bg-heatmap-0 text-inactive',
+        false: '',
+      },
     },
     defaultVariants: {
       intensity: 0,
+      isEmpty: false,
     },
   },
 );
@@ -25,13 +30,21 @@ const heatmapCellVariants = cva(
 interface HeatmapCellProps extends VariantProps<typeof heatmapCellVariants> {
   minutes: number;
   intensity: HeatmapIntensity;
+  isEmpty?: boolean;
   className?: string;
 }
 
-const HeatmapCell = ({ minutes, intensity = 0, className }: HeatmapCellProps) => {
+const HeatmapCell = ({ minutes, intensity = 0, isEmpty = false, className }: HeatmapCellProps) => {
   return (
-    <div className={cn(heatmapCellVariants({ intensity }), className)}>
-      <span className="text-inactive text-body-m-16">{formatMinutesToHourString(minutes)}h</span>
+    <div
+      className={cn(
+        heatmapCellVariants({ intensity: isEmpty ? undefined : intensity, isEmpty }),
+        className,
+      )}
+    >
+      <span className="text-inactive text-body-m-16">
+        {isEmpty ? '-' : `${formatMinutesToHourString(minutes)}h`}
+      </span>
     </div>
   );
 };

--- a/src/components/heatmaps/HeatmapLayout.tsx
+++ b/src/components/heatmaps/HeatmapLayout.tsx
@@ -1,15 +1,19 @@
 import { TIME_LABELS } from '@/constants/heatmap';
-import { TimeSlotKey } from '@/interfaces/heatmap';
+import { HeatmapPeriod, TimeSlotKey } from '@/interfaces/heatmap';
 
 interface HeatmapLayoutProps {
-  timeKeys: TimeSlotKey[];
+  type: HeatmapPeriod;
+  data?: any;
   children: React.ReactNode;
 }
 
-const HeatmapLayout = ({ timeKeys, children }: HeatmapLayoutProps) => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const HeatmapLayout = ({ type, data, children }: HeatmapLayoutProps) => {
+  const timeKeys: TimeSlotKey[] = ['dawn', 'morning', 'afternoon', 'evening'];
+
   return (
     <div className="flex w-full flex-col">
-      {/* 시간대 헤더 */}
+      {/* 시간대 헤더 - 항상 고정 */}
       <div className="mb-12 ml-40 flex gap-x-4">
         {timeKeys.map(key => (
           <div
@@ -21,7 +25,7 @@ const HeatmapLayout = ({ timeKeys, children }: HeatmapLayoutProps) => {
         ))}
       </div>
 
-      {/* 요일 or 주차별 행 */}
+      {/* 고정 레이아웃 - 항상 7일/6주 표시 */}
       <div className="flex flex-col gap-y-4">{children}</div>
     </div>
   );

--- a/src/components/heatmaps/HeatmapRow.tsx
+++ b/src/components/heatmaps/HeatmapRow.tsx
@@ -3,7 +3,7 @@ import { HeatmapIntensity, TimeSlotKey } from '@/interfaces/heatmap';
 
 interface HeatmapRowProps {
   rowLabel: string;
-  timeSlots: Record<TimeSlotKey, { minutes: number; intensity: number }>;
+  timeSlots: Record<TimeSlotKey, { minutes: number; intensity: number }> | null; // null 허용
 }
 
 const HeatmapRow = ({ rowLabel, timeSlots }: HeatmapRowProps) => {
@@ -17,12 +17,15 @@ const HeatmapRow = ({ rowLabel, timeSlots }: HeatmapRowProps) => {
 
       <div className="flex w-full gap-x-4">
         {timeKeys.map(key => {
-          const slot = timeSlots[key];
+          // 데이터가 있으면 실제 값, 없으면 기본값
+          const slot = timeSlots?.[key];
+
           return (
             <HeatmapCell
               key={key}
-              minutes={slot.minutes}
-              intensity={slot.intensity as HeatmapIntensity}
+              minutes={slot?.minutes || 0}
+              intensity={(slot?.intensity as HeatmapIntensity) || 0}
+              isEmpty={!slot}
             />
           );
         })}

--- a/src/components/heatmaps/HeatmapSection.tsx
+++ b/src/components/heatmaps/HeatmapSection.tsx
@@ -37,12 +37,12 @@ export default function HeatmapSection() {
 
   // 히트맵 렌더링
   const renderHeatmap = () => {
-    if (period === 'week' && weeklyHeatmapData) {
-      return <WeeklyHeatmap data={weeklyHeatmapData.data} />;
+    if (period === 'week') {
+      return <WeeklyHeatmap data={weeklyHeatmapData?.data} />;
     }
 
-    if (period === 'month' && monthlyHeatmapData) {
-      return <MonthlyHeatmap data={monthlyHeatmapData.data} />;
+    if (period === 'month') {
+      return <MonthlyHeatmap data={monthlyHeatmapData?.data} />;
     }
 
     return null;

--- a/src/components/heatmaps/MonthlyHeatmap.tsx
+++ b/src/components/heatmaps/MonthlyHeatmap.tsx
@@ -1,24 +1,24 @@
 import HeatmapLayout from '@/components/heatmaps/HeatmapLayout';
 import HeatmapRow from '@/components/heatmaps/HeatmapRow';
 import { WEEK_ORDER_LABELS } from '@/constants/heatmap';
-import { MonthlyHeatmapResponse, TimeSlotKey } from '@/interfaces/heatmap';
+import { MonthlyHeatmapResponse } from '@/interfaces/heatmap';
 
 interface MonthlyHeatmapProps {
-  data: MonthlyHeatmapResponse['data'];
+  data?: MonthlyHeatmapResponse['data'];
 }
 
 const MonthlyHeatmap = ({ data }: MonthlyHeatmapProps) => {
-  const timeKeys: TimeSlotKey[] = ['dawn', 'morning', 'afternoon', 'evening'];
+  // 항상 6주 레이아웃 생성
+  const rows = WEEK_ORDER_LABELS.map((label, index) => {
+    // 해당 주차의 데이터 찾기
+    const weekData = data?.days?.find(week => week.week_of_month === index + 1);
+
+    return <HeatmapRow key={label} rowLabel={label} timeSlots={weekData?.time_slots || null} />;
+  });
 
   return (
-    <HeatmapLayout timeKeys={timeKeys}>
-      {data.days.map((week, i) => (
-        <HeatmapRow
-          key={week.week_of_month}
-          rowLabel={WEEK_ORDER_LABELS[i]}
-          timeSlots={week.time_slots}
-        />
-      ))}
+    <HeatmapLayout type="monthly" data={data}>
+      {rows}
     </HeatmapLayout>
   );
 };

--- a/src/components/heatmaps/WeeklyHeatmap.tsx
+++ b/src/components/heatmaps/WeeklyHeatmap.tsx
@@ -1,20 +1,24 @@
 import HeatmapLayout from '@/components/heatmaps/HeatmapLayout';
 import HeatmapRow from '@/components/heatmaps/HeatmapRow';
 import { WEEKDAY_LABELS } from '@/constants/heatmap';
-import { TimeSlotKey, WeeklyHeatmapResponse } from '@/interfaces/heatmap';
+import { WeeklyHeatmapResponse } from '@/interfaces/heatmap';
 
 interface WeeklyHeatmapProps {
-  data: WeeklyHeatmapResponse['data'];
+  data?: WeeklyHeatmapResponse['data'];
 }
 
 const WeeklyHeatmap = ({ data }: WeeklyHeatmapProps) => {
-  const timeKeys: TimeSlotKey[] = ['dawn', 'morning', 'afternoon', 'evening'];
+  // 항상 7일 레이아웃 생성
+  const rows = WEEKDAY_LABELS.map((label, index) => {
+    // 해당 요일의 데이터 찾기
+    const dayData = data?.days?.[index];
+
+    return <HeatmapRow key={label} rowLabel={label} timeSlots={dayData?.time_slots || null} />;
+  });
 
   return (
-    <HeatmapLayout timeKeys={timeKeys}>
-      {data.days.map((day, i) => (
-        <HeatmapRow key={day.date} rowLabel={WEEKDAY_LABELS[i]} timeSlots={day.time_slots} />
-      ))}
+    <HeatmapLayout type="weekly" data={data}>
+      {rows}
     </HeatmapLayout>
   );
 };

--- a/src/interfaces/heatmap.ts
+++ b/src/interfaces/heatmap.ts
@@ -1,3 +1,6 @@
+// 히트맵 기간 타입
+export type HeatmapPeriod = 'weekly' | 'monthly';
+
 // 히트맵 셀의 작업 시간 강도
 export type HeatmapIntensity = 0 | 1 | 2 | 3 | 4;
 

--- a/src/mocks/mockResponses/heatmap/monthlyHeatmapResponse.ts
+++ b/src/mocks/mockResponses/heatmap/monthlyHeatmapResponse.ts
@@ -48,15 +48,6 @@ export const monthlyHeatmapRes = {
           evening: { minutes: 75, intensity: 2 },
         },
       },
-      {
-        week_of_month: 6,
-        time_slots: {
-          dawn: { minutes: 135, intensity: 3 },
-          morning: { minutes: 0, intensity: 0 },
-          afternoon: { minutes: 5, intensity: 1 },
-          evening: { minutes: 250, intensity: 4 },
-        },
-      },
     ],
   },
 };


### PR DESCRIPTION
## 🔗 관련 이슈 번호 (Related Issue Number)

> 이 Pull Request가 해결하고자 하는 이슈의 번호를 기재합니다. 이슈 연결을 통해 작업의 배경과 목적을 쉽게 파악할 수 있습니다. (예: Closes #123)

- Closes #255 

---

## ✨ PR 세부 내용 (PR Details)

> 이번 PR에서 어떤 작업을 했는지 상세하게 설명합니다. 코드 변경의 이유, 구현 방식, 주요 로직 등을 중심으로 작성하면 리뷰어가 이해하는 데 도움이 됩니다.

**작업 개요**
- 히트맵 컴포넌트에서 데이터가 부분적으로 없거나 로딩 중일 때도 일관된 레이아웃을 제공하도록 개선

**주요 변경사항**
- 고정 레이아웃 구조 구현
  - 주간 히트맵: 항상 7일(월~일) 고정 표시
  - 월간 히트맵: 항상 6주차 고정 표시
  - 데이터 유무와 관계없이 일관된 UI 제공
- 빈 상태 처리 추가
  - `HeatmapCell`에 `isEmpty` 상태 추가
  - 데이터가 없는 셀은 `-` 표시로 구분
  - 시각적으로 명확한 빈 상태 피드백

---

## 📸 참고할 스크린샷/영상 (Screenshots/Videos)

> 작업 내용과 관련된 시각적인 자료가 있다면 첨부합니다. UI 변경이나 새로운 기능의 동작 방식을 보여주는 스크린샷 또는 영상을 활용하면 리뷰어의 이해를 돕습니다.

**데이터 없을 때**
|주간|월간|
|--|--|
|<img width="1134" height="745" alt="image" src="https://github.com/user-attachments/assets/97f35f0f-9a49-44ff-969b-7e5c823d7fa9" />|<img width="1133" height="660" alt="image" src="https://github.com/user-attachments/assets/e4160047-ccd5-411e-a46e-125e09a080a8" />|