### PR TITLE
[Feat/#209] 주간/월간 히트맵 API 연동 및 기간 선택 기반 조건부 호출

### DIFF
--- a/src/api/heatmap.ts
+++ b/src/api/heatmap.ts
@@ -1,6 +1,19 @@
 import { getRequest } from '@/api';
 import { heatmapMapper } from '@/api/mapper/heatmapMapper';
-import { ApiMonthlyHeatmapResponse, MonthlyHeatmapResponse } from '@/interfaces/heatmap';
+import {
+  ApiMonthlyHeatmapResponse,
+  ApiWeeklyHeatmapResponse,
+  MonthlyHeatmapResponse,
+  WeeklyHeatmapResponse,
+} from '@/interfaces/heatmap';
+
+export const getWeeklyHeatmap = async (date: string): Promise<WeeklyHeatmapResponse> => {
+  const apiResponse: ApiWeeklyHeatmapResponse = await getRequest(
+    `/heatmaps/todo-timers/weekly/${date}`,
+  );
+
+  return heatmapMapper.mapApiToWeeklyHeatmap(apiResponse);
+};
 
 export const getMonthlyHeatmap = async (yearMonth: string): Promise<MonthlyHeatmapResponse> => {
   const apiResponse: ApiMonthlyHeatmapResponse = await getRequest(

--- a/src/api/heatmap.ts
+++ b/src/api/heatmap.ts
@@ -1,0 +1,11 @@
+import { getRequest } from '@/api';
+import { heatmapMapper } from '@/api/mapper/heatmapMapper';
+import { ApiMonthlyHeatmapResponse, MonthlyHeatmapResponse } from '@/interfaces/heatmap';
+
+export const getMonthlyHeatmap = async (yearMonth: string): Promise<MonthlyHeatmapResponse> => {
+  const apiResponse: ApiMonthlyHeatmapResponse = await getRequest(
+    `/heatmaps/todo-timers/monthly/${yearMonth}`,
+  );
+
+  return heatmapMapper.mapApiToMonthlyHeatmap(apiResponse);
+};

--- a/src/api/mapper/heatmapMapper.ts
+++ b/src/api/mapper/heatmapMapper.ts
@@ -1,6 +1,21 @@
-import { ApiMonthlyHeatmapResponse, MonthlyHeatmapResponse } from '@/interfaces/heatmap';
+import {
+  ApiMonthlyHeatmapResponse,
+  ApiWeeklyHeatmapResponse,
+  MonthlyHeatmapResponse,
+  WeeklyHeatmapResponse,
+} from '@/interfaces/heatmap';
 
 export const heatmapMapper = {
+  mapApiToWeeklyHeatmap: (apiResponse: ApiWeeklyHeatmapResponse): WeeklyHeatmapResponse => {
+    return {
+      success: true,
+      data: apiResponse.result.map(day => ({
+        date: day.date,
+        time_slots: day.timeSlots,
+      })),
+    };
+  },
+
   mapApiToMonthlyHeatmap: (apiResponse: ApiMonthlyHeatmapResponse): MonthlyHeatmapResponse => {
     return {
       success: true,

--- a/src/api/mapper/heatmapMapper.ts
+++ b/src/api/mapper/heatmapMapper.ts
@@ -1,0 +1,16 @@
+import { ApiMonthlyHeatmapResponse, MonthlyHeatmapResponse } from '@/interfaces/heatmap';
+
+export const heatmapMapper = {
+  mapApiToMonthlyHeatmap: (apiResponse: ApiMonthlyHeatmapResponse): MonthlyHeatmapResponse => {
+    return {
+      success: true,
+      data: {
+        month: apiResponse.result.yearMonth,
+        days: apiResponse.result.weeklyHeatmaps.map(week => ({
+          week_of_month: week.weekOfMonth,
+          time_slots: week.timeSlots,
+        })),
+      },
+    };
+  },
+};

--- a/src/components/heatmaps/HeatmapSection.tsx
+++ b/src/components/heatmaps/HeatmapSection.tsx
@@ -17,7 +17,8 @@ import usePopover from '@/hooks/usePopover';
 import { getCurrentDate, getCurrentMonth } from '@/lib/calendar';
 
 export default function HeatmapSection() {
-  const [period, setPeriod] = useState('week');
+  const [period, setPeriod] = useState<'week' | 'month'>('week');
+  const isWeek = period === 'week';
 
   const infoButtonRef = useRef<HTMLButtonElement>(null);
   const cardContainerRef = useRef<HTMLDivElement>(null);
@@ -31,18 +32,18 @@ export default function HeatmapSection() {
   };
 
   // API 호출
-  const { data: weeklyHeatmapData } = useWeeklyHeatmap(getCurrentDate());
-  const { data: monthlyHeatmapData } = useMonthlyHeatmap(getCurrentMonth());
+  const { data: weeklyHeatmapData } = useWeeklyHeatmap(getCurrentDate(), { enabled: isWeek });
+  const { data: monthlyHeatmapData } = useMonthlyHeatmap(getCurrentMonth(), { enabled: !isWeek });
   const { data: weeklyInsightData } = useWeeklyInsight();
   const { data: monthlyInsightData } = useMonthlyInsight();
 
   // 히트맵 렌더링
   const renderHeatmap = () => {
-    if (period === 'week') {
+    if (isWeek) {
       return <WeeklyHeatmap data={weeklyHeatmapData?.data} />;
     }
 
-    if (period === 'month') {
+    if (!isWeek) {
       return <MonthlyHeatmap data={monthlyHeatmapData?.data} />;
     }
 
@@ -89,7 +90,9 @@ export default function HeatmapSection() {
       <Card
         icon={<SparkleIcon className="text-gray-01" width={24} height={24} fill="currentColor" />}
         title={cardTitle}
-        extra={<Tab items={periodTabs} value={period} onChange={setPeriod} />}
+        extra={
+          <Tab items={periodTabs} value={period} onChange={v => setPeriod(v as 'week' | 'month')} />
+        }
         backgroundColor="white"
         size="heatmap"
         flexWrapExtra={true}

--- a/src/components/heatmaps/HeatmapSection.tsx
+++ b/src/components/heatmaps/HeatmapSection.tsx
@@ -14,7 +14,7 @@ import { periodTabs } from '@/constants/heatmap';
 import { useMonthlyHeatmap, useWeeklyHeatmap } from '@/hooks/useHeatmap';
 import { useMonthlyInsight, useWeeklyInsight } from '@/hooks/useInsight';
 import usePopover from '@/hooks/usePopover';
-import { getCurrentMonth } from '@/lib/calendar';
+import { getCurrentDate, getCurrentMonth } from '@/lib/calendar';
 
 export default function HeatmapSection() {
   const [period, setPeriod] = useState('week');
@@ -31,7 +31,7 @@ export default function HeatmapSection() {
   };
 
   // API 호출
-  const { data: weeklyHeatmapData } = useWeeklyHeatmap();
+  const { data: weeklyHeatmapData } = useWeeklyHeatmap(getCurrentDate());
   const { data: monthlyHeatmapData } = useMonthlyHeatmap(getCurrentMonth());
   const { data: weeklyInsightData } = useWeeklyInsight();
   const { data: monthlyInsightData } = useMonthlyInsight();

--- a/src/components/heatmaps/HeatmapSection.tsx
+++ b/src/components/heatmaps/HeatmapSection.tsx
@@ -14,6 +14,7 @@ import { periodTabs } from '@/constants/heatmap';
 import { useMonthlyHeatmap, useWeeklyHeatmap } from '@/hooks/useHeatmap';
 import { useMonthlyInsight, useWeeklyInsight } from '@/hooks/useInsight';
 import usePopover from '@/hooks/usePopover';
+import { getCurrentMonth } from '@/lib/calendar';
 
 export default function HeatmapSection() {
   const [period, setPeriod] = useState('week');
@@ -31,7 +32,7 @@ export default function HeatmapSection() {
 
   // API 호출
   const { data: weeklyHeatmapData } = useWeeklyHeatmap();
-  const { data: monthlyHeatmapData } = useMonthlyHeatmap();
+  const { data: monthlyHeatmapData } = useMonthlyHeatmap(getCurrentMonth());
   const { data: weeklyInsightData } = useWeeklyInsight();
   const { data: monthlyInsightData } = useMonthlyInsight();
 

--- a/src/components/heatmaps/WeeklyHeatmap.tsx
+++ b/src/components/heatmaps/WeeklyHeatmap.tsx
@@ -12,7 +12,7 @@ const WeeklyHeatmap = ({ data }: WeeklyHeatmapProps) => {
 
   return (
     <HeatmapLayout timeKeys={timeKeys}>
-      {data.days.map((day, i) => (
+      {data.map((day, i) => (
         <HeatmapRow key={day.date} rowLabel={WEEKDAY_LABELS[i]} timeSlots={day.time_slots} />
       ))}
     </HeatmapLayout>

--- a/src/hooks/useHeatmap.ts
+++ b/src/hooks/useHeatmap.ts
@@ -5,7 +5,7 @@ import { MonthlyHeatmapResponse, WeeklyHeatmapResponse } from '@/interfaces/heat
 
 export const useWeeklyHeatmap = (date: string) => {
   return useQuery<WeeklyHeatmapResponse>({
-    queryKey: ['weeklyHeatmap'],
+    queryKey: ['weeklyHeatmap', date],
     queryFn: () => getWeeklyHeatmap(date),
     enabled: !!date,
   });

--- a/src/hooks/useHeatmap.ts
+++ b/src/hooks/useHeatmap.ts
@@ -1,15 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getMonthlyHeatmap } from '@/api/heatmap';
+import { getMonthlyHeatmap, getWeeklyHeatmap } from '@/api/heatmap';
 import { MonthlyHeatmapResponse, WeeklyHeatmapResponse } from '@/interfaces/heatmap';
 
-export const useWeeklyHeatmap = () => {
+export const useWeeklyHeatmap = (date: string) => {
   return useQuery<WeeklyHeatmapResponse>({
     queryKey: ['weeklyHeatmap'],
-    queryFn: async () => {
-      const res = await fetch('/heatmaps/weekly');
-      return res.json();
-    },
+    queryFn: () => getWeeklyHeatmap(date),
+    enabled: !!date,
   });
 };
 

--- a/src/hooks/useHeatmap.ts
+++ b/src/hooks/useHeatmap.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { getMonthlyHeatmap } from '@/api/heatmap';
 import { MonthlyHeatmapResponse, WeeklyHeatmapResponse } from '@/interfaces/heatmap';
 
 export const useWeeklyHeatmap = () => {
@@ -12,12 +13,10 @@ export const useWeeklyHeatmap = () => {
   });
 };
 
-export const useMonthlyHeatmap = () => {
+export const useMonthlyHeatmap = (yearMonth: string) => {
   return useQuery<MonthlyHeatmapResponse>({
-    queryKey: ['monthlyHeatmap'],
-    queryFn: async () => {
-      const res = await fetch('/heatmaps/monthly');
-      return res.json();
-    },
+    queryKey: ['monthlyHeatmap', yearMonth],
+    queryFn: () => getMonthlyHeatmap(yearMonth),
+    enabled: !!yearMonth,
   });
 };

--- a/src/hooks/useHeatmap.ts
+++ b/src/hooks/useHeatmap.ts
@@ -3,18 +3,20 @@ import { useQuery } from '@tanstack/react-query';
 import { getMonthlyHeatmap, getWeeklyHeatmap } from '@/api/heatmap';
 import { MonthlyHeatmapResponse, WeeklyHeatmapResponse } from '@/interfaces/heatmap';
 
-export const useWeeklyHeatmap = (date: string) => {
+type Opts = { enabled?: boolean };
+
+export const useWeeklyHeatmap = (date: string, opts?: Opts) => {
   return useQuery<WeeklyHeatmapResponse>({
     queryKey: ['weeklyHeatmap', date],
     queryFn: () => getWeeklyHeatmap(date),
-    enabled: !!date,
+    enabled: !!date && (opts?.enabled ?? true),
   });
 };
 
-export const useMonthlyHeatmap = (yearMonth: string) => {
+export const useMonthlyHeatmap = (yearMonth: string, opts?: Opts) => {
   return useQuery<MonthlyHeatmapResponse>({
     queryKey: ['monthlyHeatmap', yearMonth],
     queryFn: () => getMonthlyHeatmap(yearMonth),
-    enabled: !!yearMonth,
+    enabled: !!yearMonth && (opts?.enabled ?? true),
   });
 };

--- a/src/interfaces/heatmap.ts
+++ b/src/interfaces/heatmap.ts
@@ -38,3 +38,16 @@ export interface MonthlyHeatmapResponse {
     }[];
   };
 }
+
+// API 명세서 기반 응답 타입
+export interface ApiMonthlyHeatmapResponse {
+  code: string;
+  message: string;
+  result: {
+    yearMonth: string;
+    weeklyHeatmaps: {
+      weekOfMonth: number;
+      timeSlots: Record<TimeSlotKey, { minutes: number; intensity: number }>;
+    }[];
+  };
+}

--- a/src/interfaces/heatmap.ts
+++ b/src/interfaces/heatmap.ts
@@ -20,11 +20,9 @@ export interface DayData {
 export interface WeeklyHeatmapResponse {
   success: boolean;
   data: {
-    days: {
-      date: string;
-      time_slots: Record<TimeSlotKey, { minutes: number; intensity: number }>;
-    }[];
-  };
+    date: string;
+    time_slots: Record<TimeSlotKey, { minutes: number; intensity: number }>;
+  }[];
 }
 
 // 월간 히트맵 응답 데이터 형식
@@ -40,6 +38,14 @@ export interface MonthlyHeatmapResponse {
 }
 
 // API 명세서 기반 응답 타입
+export interface ApiWeeklyHeatmapResponse {
+  success: boolean;
+  result: {
+    date: string;
+    timeSlots: Record<TimeSlotKey, { minutes: number; intensity: number }>;
+  }[];
+}
+
 export interface ApiMonthlyHeatmapResponse {
   code: string;
   message: string;

--- a/src/interfaces/heatmap.ts
+++ b/src/interfaces/heatmap.ts
@@ -42,7 +42,8 @@ export interface MonthlyHeatmapResponse {
 
 // API 명세서 기반 응답 타입
 export interface ApiWeeklyHeatmapResponse {
-  success: boolean;
+  code: string;
+  message: string;
   result: {
     date: string;
     timeSlots: Record<TimeSlotKey, { minutes: number; intensity: number }>;

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -55,3 +55,8 @@ export const getCurrentMonth = () => {
   const month = String(today.getMonth() + 1).padStart(2, '0');
   return `${year}-${month}`;
 };
+
+// 현재 날짜를 YYYY-MM-DD 형태로 반환하는 함수
+export const getCurrentDate = () => {
+  return new Date().toISOString().split('T')[0];
+};

--- a/src/mocks/handlers/heatmapHandlers.ts
+++ b/src/mocks/handlers/heatmapHandlers.ts
@@ -4,11 +4,11 @@ import { monthlyHeatmapRes } from '@/mocks/mockResponses/heatmap/monthlyHeatmapR
 import { weeklyHeatmapRes } from '@/mocks/mockResponses/heatmap/weeklyHeatmapResponse';
 
 export const heatmapHandlers = [
-  http.get('/heatmaps/weekly', async () => {
+  http.get('/heatmaps/todo-timers/weekly/:date', () => {
     return HttpResponse.json(weeklyHeatmapRes);
   }),
 
-  http.get('/heatmaps/monthly', () => {
+  http.get('/heatmaps/todo-timers/monthly/:yearMonth', () => {
     return HttpResponse.json(monthlyHeatmapRes);
   }),
 ];

--- a/src/mocks/mockResponses/heatmap/weeklyHeatmapResponse.ts
+++ b/src/mocks/mockResponses/heatmap/weeklyHeatmapResponse.ts
@@ -1,70 +1,68 @@
 export const weeklyHeatmapRes = {
   success: true,
-  data: {
-    days: [
-      {
-        date: '2025-07-27',
-        time_slots: {
-          dawn: { minutes: 0, intensity: 0 },
-          morning: { minutes: 15, intensity: 1 },
-          afternoon: { minutes: 75, intensity: 2 },
-          evening: { minutes: 130, intensity: 3 },
-        },
+  data: [
+    {
+      date: '2025-07-27',
+      time_slots: {
+        dawn: { minutes: 0, intensity: 0 },
+        morning: { minutes: 15, intensity: 1 },
+        afternoon: { minutes: 75, intensity: 2 },
+        evening: { minutes: 130, intensity: 3 },
       },
-      {
-        date: '2025-07-28',
-        time_slots: {
-          dawn: { minutes: 250, intensity: 4 },
-          morning: { minutes: 0, intensity: 0 },
-          afternoon: { minutes: 5, intensity: 1 },
-          evening: { minutes: 60, intensity: 2 },
-        },
+    },
+    {
+      date: '2025-07-28',
+      time_slots: {
+        dawn: { minutes: 250, intensity: 4 },
+        morning: { minutes: 0, intensity: 0 },
+        afternoon: { minutes: 5, intensity: 1 },
+        evening: { minutes: 60, intensity: 2 },
       },
-      {
-        date: '2025-07-29',
-        time_slots: {
-          dawn: { minutes: 150, intensity: 3 },
-          morning: { minutes: 240, intensity: 4 },
-          afternoon: { minutes: 0, intensity: 0 },
-          evening: { minutes: 45, intensity: 1 },
-        },
+    },
+    {
+      date: '2025-07-29',
+      time_slots: {
+        dawn: { minutes: 150, intensity: 3 },
+        morning: { minutes: 240, intensity: 4 },
+        afternoon: { minutes: 0, intensity: 0 },
+        evening: { minutes: 45, intensity: 1 },
       },
-      {
-        date: '2025-07-30',
-        time_slots: {
-          dawn: { minutes: 90, intensity: 2 },
-          morning: { minutes: 0, intensity: 0 },
-          afternoon: { minutes: 25, intensity: 1 },
-          evening: { minutes: 130, intensity: 3 },
-        },
+    },
+    {
+      date: '2025-07-30',
+      time_slots: {
+        dawn: { minutes: 90, intensity: 2 },
+        morning: { minutes: 0, intensity: 0 },
+        afternoon: { minutes: 25, intensity: 1 },
+        evening: { minutes: 130, intensity: 3 },
       },
-      {
-        date: '2025-07-31',
-        time_slots: {
-          dawn: { minutes: 250, intensity: 4 },
-          morning: { minutes: 15, intensity: 1 },
-          afternoon: { minutes: 0, intensity: 0 },
-          evening: { minutes: 75, intensity: 2 },
-        },
+    },
+    {
+      date: '2025-07-31',
+      time_slots: {
+        dawn: { minutes: 250, intensity: 4 },
+        morning: { minutes: 15, intensity: 1 },
+        afternoon: { minutes: 0, intensity: 0 },
+        evening: { minutes: 75, intensity: 2 },
       },
-      {
-        date: '2025-08-01',
-        time_slots: {
-          dawn: { minutes: 135, intensity: 3 },
-          morning: { minutes: 0, intensity: 0 },
-          afternoon: { minutes: 5, intensity: 1 },
-          evening: { minutes: 250, intensity: 4 },
-        },
+    },
+    {
+      date: '2025-08-01',
+      time_slots: {
+        dawn: { minutes: 135, intensity: 3 },
+        morning: { minutes: 0, intensity: 0 },
+        afternoon: { minutes: 5, intensity: 1 },
+        evening: { minutes: 250, intensity: 4 },
       },
-      {
-        date: '2025-08-02',
-        time_slots: {
-          dawn: { minutes: 60, intensity: 2 },
-          morning: { minutes: 110, intensity: 3 },
-          afternoon: { minutes: 0, intensity: 0 },
-          evening: { minutes: 30, intensity: 1 },
-        },
+    },
+    {
+      date: '2025-08-02',
+      time_slots: {
+        dawn: { minutes: 60, intensity: 2 },
+        morning: { minutes: 110, intensity: 3 },
+        afternoon: { minutes: 0, intensity: 0 },
+        evening: { minutes: 30, intensity: 1 },
       },
-    ],
-  },
+    },
+  ],
 };


### PR DESCRIPTION
## 🔗 관련 이슈 번호 (Related Issue Number)

> 이 Pull Request가 해결하고자 하는 이슈의 번호를 기재합니다. 이슈 연결을 통해 작업의 배경과 목적을 쉽게 파악할 수 있습니다. (예: Closes #123)

- Closes #209

---

## ✨ PR 세부 내용 (PR Details)

> 이번 PR에서 어떤 작업을 했는지 상세하게 설명합니다. 코드 변경의 이유, 구현 방식, 주요 로직 등을 중심으로 작성하면 리뷰어가 이해하는 데 도움이 됩니다.

**작업 개요**
- 주간/월간 히트맵 API 연동 및 데이터 매퍼, 타입 정의 추가
- 동적 파라미터(date, yearMonth)를 통한 API 호출
- 선택된 기간(week/month)에 따라 쿼리 실행을 제어하는 로직 적용

**주요 변경사항**
- `useWeeklyHeatmap`, `useMonthlyHeatmap` 훅 개선
  - `enabled` 옵션 지원 → 선택된 탭에 따라 호출 여부 제어
  - `queryKey`에 파라미터(`date`/`yearMonth`) 포함 → 캐시 분리
- HeatmapSection 리팩터링
  - period 상태값을 기반으로 필요한 데이터만 요청
  - 불필요한 API 호출 방지
- MSW 핸들러 경로 수정 → 실제 API 경로(`/heatmaps/todo-timers/...`)와 일치