### PR TITLE
[Feat/#275] 히트맵 영역 에러 처리 및 커스텀 훅 리팩터링

### DIFF
--- a/src/components/heatmaps/HeatmapSection.tsx
+++ b/src/components/heatmaps/HeatmapSection.tsx
@@ -8,17 +8,25 @@ import MonthlyHeatmap from '@/components/heatmaps/MonthlyHeatmap';
 import WeeklyHeatmap from '@/components/heatmaps/WeeklyHeatmap';
 import InsightCard from '@/components/insight/InsightCard';
 import Card from '@/components/ui/Card';
+import ErrorFallback from '@/components/ui/ErrorFallback';
 import { IconButton } from '@/components/ui/IconButton';
 import Tab from '@/components/ui/Tab';
 import { periodTabs } from '@/constants/heatmap';
-import { useMonthlyHeatmap, useWeeklyHeatmap } from '@/hooks/useHeatmap';
-import { useMonthlyInsight, useWeeklyInsight } from '@/hooks/useInsight';
+import { useHeatmapSection } from '@/hooks/useHeatmapsSection';
 import usePopover from '@/hooks/usePopover';
-import { getCurrentDate, getCurrentMonth } from '@/lib/calendar';
 
 export default function HeatmapSection() {
   const [period, setPeriod] = useState<'week' | 'month'>('week');
   const isWeek = period === 'week';
+
+  const {
+    weeklyHeatmapData,
+    monthlyHeatmapData,
+    weeklyInsightData,
+    monthlyInsightData,
+    hasError,
+    handleRetry,
+  } = useHeatmapSection(period);
 
   const infoButtonRef = useRef<HTMLButtonElement>(null);
   const cardContainerRef = useRef<HTMLDivElement>(null);
@@ -30,12 +38,6 @@ export default function HeatmapSection() {
       popover.open(infoButtonRef.current, cardContainerRef.current);
     }
   };
-
-  // API 호출
-  const { data: weeklyHeatmapData } = useWeeklyHeatmap(getCurrentDate(), { enabled: isWeek });
-  const { data: monthlyHeatmapData } = useMonthlyHeatmap(getCurrentMonth(), { enabled: !isWeek });
-  const { data: weeklyInsightData } = useWeeklyInsight();
-  const { data: monthlyInsightData } = useMonthlyInsight();
 
   // 히트맵 렌더링
   const renderHeatmap = () => {
@@ -91,16 +93,34 @@ export default function HeatmapSection() {
         icon={<SparkleIcon className="text-gray-01" width={24} height={24} fill="currentColor" />}
         title={cardTitle}
         extra={
-          <Tab items={periodTabs} value={period} onChange={v => setPeriod(v as 'week' | 'month')} />
+          !hasError && (
+            <Tab
+              items={periodTabs}
+              value={period}
+              onChange={v => setPeriod(v as 'week' | 'month')}
+            />
+          )
         }
         backgroundColor="white"
         size="heatmap"
         flexWrapExtra={true}
       >
-        <div className="flex h-full flex-1 flex-col gap-12">
-          <div className="flex flex-shrink-0 justify-center">{renderHeatmap()}</div>
-          <div className="flex flex-1">{renderInsightCard()}</div>
-        </div>
+        {hasError ? (
+          // 에러처리
+          <div className="flex h-full w-full justify-center">
+            <ErrorFallback
+              type="general"
+              title="작업시간 분석 데이터를 불러올 수 없어요"
+              onRetry={handleRetry}
+            />
+          </div>
+        ) : (
+          // 정상처리
+          <div className="flex h-full flex-1 flex-col gap-12">
+            <div className="flex flex-shrink-0 justify-center">{renderHeatmap()}</div>
+            <div className="flex flex-1">{renderInsightCard()}</div>
+          </div>
+        )}
       </Card>
 
       {popover.isOpen && <HeatmapInfoPopover onClose={popover.close} position={popover.position} />}

--- a/src/components/heatmaps/HeatmapSection.tsx
+++ b/src/components/heatmaps/HeatmapSection.tsx
@@ -108,11 +108,7 @@ export default function HeatmapSection() {
         {hasError ? (
           // 에러처리
           <div className="flex h-full w-full justify-center">
-            <ErrorFallback
-              type="general"
-              title="작업시간 분석 데이터를 불러올 수 없어요"
-              onRetry={handleRetry}
-            />
+            <ErrorFallback type="general" title="데이터를 불러올 수 없어요" onRetry={handleRetry} />
           </div>
         ) : (
           // 정상처리

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -32,9 +32,8 @@ const buttonVariants = cva('flex cursor-pointer items-center justify-center', {
       noteHeaderWhite: 'md:text-body-sb-20 text-body-m-16 text-white',
       tempNote: 'md:text-body-m-16 sm:text-body-m-12 text-white',
       sideNote: 'md:text-body-m-20 sm:text-body-m-16 text-white',
-      errorPrimary: 'sm:text-body-m-16 md:text-body-sb-20 text-white',
-      errorSecondary:
-        'sm:text-body-m-16 md:text-body-sb-20 text-primary-01 hover:text-primary-01-hover',
+      errorPrimary: 'text-body-m-16 text-white',
+      errorSecondary: 'text-body-m-16 text-primary-01 hover:text-primary-01-hover',
     },
     size: {
       auth: 'h-62 w-600 px-20 py-24 sm:h-44 sm:w-full sm:max-w-343 md:h-62 md:w-full md:max-w-600',
@@ -51,7 +50,7 @@ const buttonVariants = cva('flex cursor-pointer items-center justify-center', {
       scheduleDashboard: 'h-40 w-120 sm:w-160',
       tempNote: 'h-40 w-84',
       sideNote: 'h-48 w-260',
-      error: 'sm:h-44 sm:w-200 md:h-62 md:w-400',
+      error: 'h-44 w-200',
     },
     rounded: {
       none: 'rounded-none',

--- a/src/components/ui/ErrorFallback.tsx
+++ b/src/components/ui/ErrorFallback.tsx
@@ -37,7 +37,7 @@ const ERROR_CONFIGS: Record<ErrorType, ErrorConfig> = {
     Icon: GeneralErrorIcon,
     title: '문제가 발생했어요',
     subTitle: '잠시 후 다시 시도해 주세요',
-    iconWrapClass: 'sm:h-100 sm:w-100 md:h-200 md:w-200',
+    iconWrapClass: 'h-100 w-100',
     primary: { label: '다시 시도', action: 'retry' },
     secondary: { label: '홈으로', action: 'navigate' },
   },
@@ -45,7 +45,7 @@ const ERROR_CONFIGS: Record<ErrorType, ErrorConfig> = {
     Icon: NotFoundErrorIcon,
     title: '페이지를 찾을 수 없어요',
     subTitle: '요청하신 페이지가 존재하지 않습니다',
-    iconWrapClass: 'sm:h-100 sm:w-150 md:h-200 md:w-300',
+    iconWrapClass: 'h-100 w-150',
     primary: { label: '홈으로', action: 'navigate' },
     secondary: { label: '이전 페이지', action: 'back' },
   },
@@ -125,7 +125,7 @@ const ErrorFallback = ({
       </div>
 
       {/* Action Buttons */}
-      <div className="flex w-full flex-col items-center justify-center gap-6 sm:mt-40 md:mt-60">
+      <div className="mt-40 flex w-full flex-col items-center justify-center gap-6">
         <Button
           variant="errorPrimary"
           text="errorPrimary"

--- a/src/components/ui/ErrorFallback.tsx
+++ b/src/components/ui/ErrorFallback.tsx
@@ -109,7 +109,7 @@ const ErrorFallback = ({
   };
 
   return (
-    <div className="flex w-220 flex-col items-center justify-center md:w-400">
+    <div className="flex w-300 flex-col items-center justify-center">
       {/* Error Icon */}
       <div className={config.iconWrapClass}>
         <Icon
@@ -119,9 +119,9 @@ const ErrorFallback = ({
       </div>
 
       {/* Error Messages */}
-      <div className="flex w-full flex-col text-center sm:gap-12 md:gap-16">
-        <h1 className="sm:text-body-sb-20 md:text-display-24 text-text-02">{displayTitle}</h1>
-        <p className="sm:text-body-m-16 md:text-body-m-20 text-text-03">{displaySubTitle}</p>
+      <div className="flex w-full flex-col gap-12 text-center">
+        <h1 className="text-body-sb-20 text-text-02">{displayTitle}</h1>
+        <p className="text-body-m-16 text-text-03">{displaySubTitle}</p>
       </div>
 
       {/* Action Buttons */}

--- a/src/hooks/useHeatmapsSection.ts
+++ b/src/hooks/useHeatmapsSection.ts
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+
+import { useMonthlyHeatmap, useWeeklyHeatmap } from '@/hooks/useHeatmap';
+import { useMonthlyInsight, useWeeklyInsight } from '@/hooks/useInsight';
+import { getCurrentDate, getCurrentMonth } from '@/lib/calendar';
+
+export const useHeatmapSection = (period: 'week' | 'month') => {
+  const isWeek = period === 'week';
+
+  const weeklyHeatmap = useWeeklyHeatmap(getCurrentDate(), { enabled: isWeek });
+  const monthlyHeatmap = useMonthlyHeatmap(getCurrentMonth(), { enabled: !isWeek });
+  const weeklyInsight = useWeeklyInsight();
+  const monthlyInsight = useMonthlyInsight();
+
+  const currentHeatmap = isWeek ? weeklyHeatmap : monthlyHeatmap;
+  const currentInsight = isWeek ? weeklyInsight : monthlyInsight;
+
+  const hasError = !!currentHeatmap.error || !!currentInsight.error;
+
+  const handleRetry = useCallback(() => {
+    currentHeatmap.refetch();
+    currentInsight.refetch();
+  }, [currentHeatmap, currentInsight]);
+
+  return {
+    weeklyHeatmapData: weeklyHeatmap.data,
+    monthlyHeatmapData: monthlyHeatmap.data,
+    weeklyInsightData: weeklyInsight.data,
+    monthlyInsightData: monthlyInsight.data,
+    hasError,
+    handleRetry,
+  };
+};


### PR DESCRIPTION
## 🔗 관련 이슈 번호 (Related Issue Number)

> 이 Pull Request가 해결하고자 하는 이슈의 번호를 기재합니다. 이슈 연결을 통해 작업의 배경과 목적을 쉽게 파악할 수 있습니다. (예: Closes #123)

- Closes #275

---

## ✨ PR 세부 내용 (PR Details)

> 이번 PR에서 어떤 작업을 했는지 상세하게 설명합니다. 코드 변경의 이유, 구현 방식, 주요 로직 등을 중심으로 작성하면 리뷰어가 이해하는 데 도움이 됩니다.

**작업 개요**
- HeatmapSection 컴포넌트에 에러 처리 기능 추가 및 코드 리팩터링

**주요 변경사항**
- `useHeatmapSection` 커스텀 훅 생성으로 데이터 fetching 로직 분리
- 에러 상태에서 `ErrorFallback` 컴포넌트를 통한 일관된 에러 UI 제공
- `ErrorFallback` 컴포넌트의 반응형 크기 단순화 (sm:/md: 제거)

---

## 📸 참고할 스크린샷/영상 (Screenshots/Videos)

> 작업 내용과 관련된 시각적인 자료가 있다면 첨부합니다. UI 변경이나 새로운 기능의 동작 방식을 보여주는 스크린샷 또는 영상을 활용하면 리뷰어의 이해를 돕습니다.

|모바일|태블릿,데스크탑|
|--|--|
|<img width="549" height="973" alt="image" src="https://github.com/user-attachments/assets/121fe80a-c6f7-4d28-8b67-089742d3eb41" />|<img width="2828" height="1028" alt="image" src="https://github.com/user-attachments/assets/42f7190c-28e0-4ed8-a1ff-98c3b19485c6" />|


