### PR TITLE
[FEAT/#280] 시연을 위한 InsightCard 상태별 variant 추가

### DIFF
--- a/src/components/heatmaps/HeatmapSection.tsx
+++ b/src/components/heatmaps/HeatmapSection.tsx
@@ -19,14 +19,8 @@ export default function HeatmapSection() {
   const [period, setPeriod] = useState<'week' | 'month'>('week');
   const isWeek = period === 'week';
 
-  const {
-    weeklyHeatmapData,
-    monthlyHeatmapData,
-    weeklyInsightData,
-    monthlyInsightData,
-    hasError,
-    handleRetry,
-  } = useHeatmapSection(period);
+  const { weeklyHeatmapData, monthlyHeatmapData, hasError, handleRetry } =
+    useHeatmapSection(period);
 
   const infoButtonRef = useRef<HTMLButtonElement>(null);
   const cardContainerRef = useRef<HTMLDivElement>(null);
@@ -54,23 +48,26 @@ export default function HeatmapSection() {
 
   // 인사이트 카드 렌더링
   const renderInsightCard = () => {
-    if (period === 'week') {
-      return weeklyInsightData?.success && weeklyInsightData.data.insights.length > 0 ? (
-        <InsightCard variant="weekly" items={weeklyInsightData.data.insights} />
-      ) : (
-        <InsightCard variant="empty" />
-      );
-    }
+    return <InsightCard variant="no-work-time" />;
 
-    if (period === 'month') {
-      return monthlyInsightData?.success && monthlyInsightData.data.insights.length > 0 ? (
-        <InsightCard variant="monthly" items={monthlyInsightData.data.insights} />
-      ) : (
-        <InsightCard variant="empty" />
-      );
-    }
+    // TODO
+    // if (period === 'week') {
+    //   return weeklyInsightData?.success && weeklyInsightData.data.insights.length > 0 ? (
+    //     <InsightCard variant="weekly" items={weeklyInsightData.data.insights} />
+    //   ) : (
+    //     <InsightCard variant="no-data" />
+    //   );
+    // }
 
-    return null;
+    // if (period === 'month') {
+    //   return monthlyInsightData?.success && monthlyInsightData.data.insights.length > 0 ? (
+    //     <InsightCard variant="monthly" items={monthlyInsightData.data.insights} />
+    //   ) : (
+    //     <InsightCard variant="no-data" />
+    //   );
+    // }
+
+    // return null;
   };
 
   const cardTitle = (

--- a/src/components/insight/InsightCard.tsx
+++ b/src/components/insight/InsightCard.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils';
 
 interface InsightCardProps {
-  variant: 'empty' | 'weekly' | 'monthly';
+  variant: 'no-data' | 'no-work-time' | 'weekly' | 'monthly';
   items?: React.ReactNode[];
   className?: string;
 }
@@ -12,7 +12,7 @@ const InsightCard = ({ variant, items = [], className }: InsightCardProps) => {
   const baseClasses =
     'rounded-20 flex w-full flex-col py-12 px-12 md:px-20 bg-insightContainer gap-12 h-full';
 
-  if (variant === 'empty') {
+  if (variant === 'no-data') {
     return (
       <div className={cn(baseClasses, 'items-center justify-center text-center', className)}>
         <div className="text-body-m-16 text-text-03 flex flex-col items-center gap-8">
@@ -23,6 +23,22 @@ const InsightCard = ({ variant, items = [], className }: InsightCardProps) => {
             인사이트를 제공할 수 없어요 :(
           </p>
           <p>작업을 시작해보세요!</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (variant === 'no-work-time') {
+    return (
+      <div className={cn(baseClasses, 'items-center justify-center text-center', className)}>
+        <div className="text-body-m-16 text-text-03 flex flex-col items-center gap-8">
+          <TimerIcon className="text-inactive" width={32} height={32} fill="currentColor" />
+
+          <p>
+            충분한 작업 데이터가 쌓이면 <br className="md:hidden" />
+            인사이트를 제공해드려요 :)
+          </p>
+          <p>목표를 설정하고 작업을 시작해보세요!</p>
         </div>
       </div>
     );

--- a/src/stories/insight/InsightCard.stories.tsx
+++ b/src/stories/insight/InsightCard.stories.tsx
@@ -9,8 +9,8 @@ const meta: Meta<typeof InsightCard> = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['empty', 'weekly', 'monthly'],
-      description: '카드 타입 (empty, weekly, monthly)',
+      options: ['no-data', 'weekly', 'monthly'],
+      description: '카드 타입 (no-data, weekly, monthly)',
     },
     className: {
       control: false,
@@ -29,9 +29,9 @@ const meta: Meta<typeof InsightCard> = {
 export default meta;
 type Story = StoryObj<typeof InsightCard>;
 
-export const Empty: Story = {
+export const NoData: Story = {
   args: {
-    variant: 'empty',
+    variant: 'no-data',
   },
 };
 


### PR DESCRIPTION
## 🔗 관련 이슈 번호 (Related Issue Number)

> 이 Pull Request가 해결하고자 하는 이슈의 번호를 기재합니다. 이슈 연결을 통해 작업의 배경과 목적을 쉽게 파악할 수 있습니다. (예: Closes #123)

- Closes #280

---

## ✨ PR 세부 내용 (PR Details)

> 이번 PR에서 어떤 작업을 했는지 상세하게 설명합니다. 코드 변경의 이유, 구현 방식, 주요 로직 등을 중심으로 작성하면 리뷰어가 이해하는 데 도움이 됩니다.

**작업 개요**
- 현재 api 구현이 되어 있지 않아 개발모드/운영모드 범용적으로 사용 가능한 상태를 추가하여 렌더링
- 참고: 기존 기획했던 로직은 api 연결되면 살리기 위해 주석처리되어 있음

**주요 변경사항**
- `InsightCard` 컴포넌트 variant 확장: `'empty'` → `'no-data'`, `'no-work-time'` 분리

---

## 📸 참고할 스크린샷/영상 (Screenshots/Videos)

> 작업 내용과 관련된 시각적인 자료가 있다면 첨부합니다. UI 변경이나 새로운 기능의 동작 방식을 보여주는 스크린샷 또는 영상을 활용하면 리뷰어의 이해를 돕습니다.

|모바일|태블릿,데스크탑|
|--|--|
|<img width="549" height="976" alt="image" src="https://github.com/user-attachments/assets/d1433661-23f3-4567-b347-63b1427e9a13" />|<img width="1151" height="942" alt="image" src="https://github.com/user-attachments/assets/0c11a59c-c28f-4a93-864c-5e7357390229" />|


