### PR TITLE
[Fix/#206] 히트맵 새로고침 기능 추가, 캘린더 목표 표시 개선, 화살표 아이콘 스타일 수정

### DIFF
--- a/src/components/calendar/CalendarCell.tsx
+++ b/src/components/calendar/CalendarCell.tsx
@@ -12,7 +12,6 @@ interface CalendarCellProps {
 const CalendarCell = ({ date, goals = [], onClick, className }: CalendarCellProps) => {
   const hasGoals = goals.length > 0;
   const firstGoal = goals[0];
-  const goalName = goals.length === 1 ? firstGoal.title : goals.length;
   const goalColorName = firstGoal ? getGoalBackgroundColorClass(firstGoal.color) : null;
 
   const handleClick = (event: React.MouseEvent) => {
@@ -36,7 +35,7 @@ const CalendarCell = ({ date, goals = [], onClick, className }: CalendarCellProp
         <div
           className={`text-body-16 rounded-4 ${goalColorName} flex w-full items-center justify-center truncate px-2 text-center text-white`}
         >
-          {goalName}
+          {goals.length}
         </div>
       )}
     </button>

--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -85,23 +85,23 @@ const iconConfig = {
   },
   back: {
     component: PrevIcon,
-    className: 'fill-none',
+    className: 'arrow-left-icon',
   },
   prev: {
     component: PrevIcon,
-    className: 'fill-none',
+    className: 'arrow-left-icon',
   },
   next: {
     component: NextIcon,
-    className: 'fill-none',
+    className: 'arrow-right-icon',
   },
   paginationArrowPrev: {
     component: PrevIcon,
-    className: 'fill-none',
+    className: 'arrow-left-icon',
   },
   paginationArrowNext: {
     component: NextIcon,
-    className: 'fill-none',
+    className: 'arrow-right-icon',
   },
   kebab: {
     component: KebabIcon,

--- a/src/hooks/useHeatmap.ts
+++ b/src/hooks/useHeatmap.ts
@@ -10,6 +10,8 @@ export const useWeeklyHeatmap = (date: string, opts?: Opts) => {
     queryKey: ['weeklyHeatmap', date],
     queryFn: () => getWeeklyHeatmap(date),
     enabled: !!date && (opts?.enabled ?? true),
+    refetchInterval: 10 * 1000, // 10초마다 새로고침
+    refetchOnWindowFocus: true, // 윈도우 포커스 시 새로고침
   });
 };
 
@@ -18,5 +20,7 @@ export const useMonthlyHeatmap = (yearMonth: string, opts?: Opts) => {
     queryKey: ['monthlyHeatmap', yearMonth],
     queryFn: () => getMonthlyHeatmap(yearMonth),
     enabled: !!yearMonth && (opts?.enabled ?? true),
+    refetchInterval: 10 * 1000, // 10초마다 새로고침
+    refetchOnWindowFocus: true, // 윈도우 포커스 시 새로고침
   });
 };

--- a/src/hooks/useHeatmapsSection.ts
+++ b/src/hooks/useHeatmapsSection.ts
@@ -1,10 +1,14 @@
 import { useCallback } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
+
 import { useMonthlyHeatmap, useWeeklyHeatmap } from '@/hooks/useHeatmap';
 import { useMonthlyInsight, useWeeklyInsight } from '@/hooks/useInsight';
 import { getCurrentDate, getCurrentMonth } from '@/lib/calendar';
 
 export const useHeatmapSection = (period: 'week' | 'month') => {
+  const queryClient = useQueryClient();
+
   const isWeek = period === 'week';
 
   const weeklyHeatmap = useWeeklyHeatmap(getCurrentDate(), { enabled: isWeek });
@@ -22,6 +26,11 @@ export const useHeatmapSection = (period: 'week' | 'month') => {
     currentInsight.refetch();
   }, [currentHeatmap, currentInsight]);
 
+  const refreshHeatmapData = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['heatmap'] });
+    queryClient.invalidateQueries({ queryKey: ['insight'] });
+  }, [queryClient]);
+
   return {
     weeklyHeatmapData: weeklyHeatmap.data,
     monthlyHeatmapData: monthlyHeatmap.data,
@@ -29,5 +38,6 @@ export const useHeatmapSection = (period: 'week' | 'month') => {
     monthlyInsightData: monthlyInsight.data,
     hasError,
     handleRetry,
+    refreshHeatmapData,
   };
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -592,3 +592,17 @@
 .notfound-error-icon path:last-child {
   fill: #c3cad6 !important;
 }
+
+/* 화살표 아이콘 */
+.arrow-left-icon {
+  fill: none !important;
+}
+.arrow-left-icon path {
+  stroke: #515660 !important;
+}
+.arrow-right-icon {
+  fill: none !important;
+}
+.arrow-right-icon path {
+  stroke: #515660 !important;
+}


### PR DESCRIPTION
## 📖 스토리북 링크 (Storybook Link)

> 변경된 UI 컴포넌트를 시각적으로 확인하고 인터랙션해볼 수 있는 스토리북 링크를 첨부합니다.

- [바로가기]()

---

## 🔗 관련 이슈 번호 (Related Issue Number)

> 이 Pull Request가 해결하고자 하는 이슈의 번호를 기재합니다. 이슈 연결을 통해 작업의 배경과 목적을 쉽게 파악할 수 있습니다. (예: Closes #123)

- Closes #206

---

## ✨ PR 세부 내용 (PR Details)

> 이번 PR에서 어떤 작업을 했는지 상세하게 설명합니다. 코드 변경의 이유, 구현 방식, 주요 로직 등을 중심으로 작성하면 리뷰어가 이해하는 데 도움이 됩니다.

**작업 개요**
- Heatmap 데이터 갱신 기능 추가
- 캘린더 셀 목표 표시 방식을 단일 목표명 → 목표 개수로 변경
- 네비게이션 화살표 아이콘 스타일 및 클래스 네이밍 개선

**주요 변경사항**
- useHeatmapSection
  - useQueryClient 도입
  - refreshHeatmapData 콜백 추가 (heatmap/insight 쿼리 무효화)
  - 주/월간 heatmap 쿼리에 refetchInterval과 refetchOnWindowFocus 설정 추가
- CalendarCell
  - 목표명이 아닌 goals.length(목표 개수) 표시로 변경
  - 불필요한 goalName 변수 제거
- IconButton & globals.css
  - 기존 fill-none 클래스 제거
  - 명확한 클래스명(arrow-left-icon, arrow-right-icon)으로 변경
  - 글로벌 스타일에서 fill/stroke 지정하여 일관성 있는 화살표 아이콘 색상 적용