### PR TITLE
[Style/#311] 모든 목표 리스트 페이지 반응형 디자인 수정

### DIFF
--- a/src/components/goals/goalList/GoalCard.tsx
+++ b/src/components/goals/goalList/GoalCard.tsx
@@ -84,7 +84,7 @@ const GoalCard = ({ goal }: GoalCardProps) => {
 
   return (
     <div
-      className="rounded-20 relative flex h-340 max-w-480 cursor-pointer flex-col overflow-hidden bg-white shadow-lg"
+      className="rounded-20 relative flex h-300 max-w-408 cursor-pointer flex-col overflow-hidden bg-white shadow-lg"
       onClick={handleCardClick}
     >
       {/* 왼쪽 색상 바 */}

--- a/src/components/goals/goalList/GoalsClientContent.tsx
+++ b/src/components/goals/goalList/GoalsClientContent.tsx
@@ -51,7 +51,7 @@ const GoalsClientContent = () => {
 
   return (
     <div className="relative min-h-screen px-24">
-      <div className="mx-auto max-w-1504 pb-118">
+      <div className="mx-auto pb-118">
         {/* 헤더 */}
         <GoalsHeader totalCount={goalsData?.pagination?.totalCount || 0} />
 

--- a/src/components/goals/goalList/GoalsList.tsx
+++ b/src/components/goals/goalList/GoalsList.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
+'use client';
 
+import { useSidebar } from '@/app/providers/SidebarProvider';
 import { GoalSummary } from '@/interfaces/goal';
 
 import GoalCard from './GoalCard';
@@ -8,50 +9,12 @@ interface GoalsListProps {
   goals: GoalSummary[];
 }
 
-const CARD_GAP = 32; // gap-32
-const CARD_MIN_WIDTH = 480; // GoalCard의 max-w-480 기준
-
-//브라우저 리사이징 반응형 대응
-const useResponsiveColumns = (minWidth: number, gap: number) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [columns, setColumns] = useState(1);
-
-  useEffect(() => {
-    //최대 컬럼 수 계산
-    const updateColumns = (containerWidth: number) => {
-      const maxColumns = Math.floor((containerWidth + gap) / (minWidth + gap));
-      setColumns(Math.max(1, maxColumns));
-    };
-
-    const resizeObserver = new ResizeObserver(entries => {
-      const [entry] = entries;
-      if (entry) {
-        updateColumns(entry.contentRect.width);
-      }
-    });
-
-    if (containerRef.current) {
-      updateColumns(containerRef.current.offsetWidth);
-      // ResizeObserver로 컨테이너 크기 변화 감지
-      resizeObserver.observe(containerRef.current);
-    }
-
-    return () => resizeObserver.disconnect();
-  }, [minWidth, gap]);
-
-  return { containerRef, columns };
-};
-
 const GoalsList = ({ goals }: GoalsListProps) => {
-  const { containerRef, columns } = useResponsiveColumns(CARD_MIN_WIDTH, CARD_GAP);
+  const { isOpen } = useSidebar();
 
   return (
     <div
-      ref={containerRef}
-      className="grid max-w-1504 justify-center gap-32"
-      style={{
-        gridTemplateColumns: `repeat(${columns}, minmax(0, 480px))`,
-      }}
+      className={`grid sm:grid-cols-1 sm:gap-16 md:grid-cols-2 md:gap-12 lg:gap-24 xl:grid-cols-3 ${isOpen ? 'lg:w-866 lg:grid-cols-2 xl:w-full' : 'lg:grid-cols-3'}`}
     >
       {goals.map(goal => (
         <GoalCard key={goal.goalId} goal={goal} />

--- a/src/components/goals/goalList/GoalsList.tsx
+++ b/src/components/goals/goalList/GoalsList.tsx
@@ -3,6 +3,8 @@
 import { useSidebar } from '@/app/providers/SidebarProvider';
 import { GoalSummary } from '@/interfaces/goal';
 
+import NoGoalsGuide from '../NoGoalsGuide';
+
 import GoalCard from './GoalCard';
 
 interface GoalsListProps {
@@ -13,13 +15,21 @@ const GoalsList = ({ goals }: GoalsListProps) => {
   const { isOpen } = useSidebar();
 
   return (
-    <div
-      className={`grid sm:grid-cols-1 sm:gap-16 md:grid-cols-2 md:gap-12 lg:gap-24 xl:grid-cols-3 ${isOpen ? 'lg:w-866 lg:grid-cols-2 xl:w-full' : 'lg:grid-cols-3'}`}
-    >
-      {goals.map(goal => (
-        <GoalCard key={goal.goalId} goal={goal} />
-      ))}
-    </div>
+    <>
+      {goals.length > 0 ? (
+        <div
+          className={`grid sm:grid-cols-1 sm:gap-16 md:grid-cols-2 md:gap-12 lg:gap-24 xl:grid-cols-3 ${isOpen ? 'lg:w-866 lg:grid-cols-2 xl:w-full' : 'lg:grid-cols-3'}`}
+        >
+          {goals.map(goal => (
+            <GoalCard key={goal.goalId} goal={goal} />
+          ))}
+        </div>
+      ) : (
+        <div className="flex h-full w-full items-center justify-center">
+          <NoGoalsGuide />
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -74,7 +74,7 @@ export default function Sidebar() {
     <>
       <div
         className={cn(
-          `border-line rounded-tr-50 rounded-br-50 min-h-screen w-100 transform flex-col items-center gap-36 border-r bg-white px-18 pt-40 transition-all duration-200 ease-in-out sm:fixed sm:hidden md:fixed md:flex md:w-80 lg:static lg:flex`,
+          `border-line rounded-tr-50 rounded-br-50 min-h-screen w-100 transform flex-col items-center gap-36 border-r bg-white px-18 pt-40 transition-all duration-200 ease-in-out sm:fixed sm:hidden md:static md:flex md:w-80 lg:static lg:flex`,
           {
             'translate-x-0 opacity-100': !isOpen,
             'pointer-events-none -translate-x-full opacity-0': isOpen,


### PR DESCRIPTION
## 🔗 관련 이슈 번호 (Related Issue Number)

- Closes #311 

---

## ✨ PR 세부 내용 (PR Details)

**작업 개요**

- 모든 목표 리스트 페이지 반응형 디자인 수정


---

## 📸 참고할 스크린샷/영상 (Screenshots/Videos)

**UI 변경 전/후 스크린샷**

- PC

- <img width="1007" height="849" alt="image" src="https://github.com/user-attachments/assets/7ed6501c-003e-4b4c-90ec-ea245b0b817e" />

- <img width="936" height="780" alt="image" src="https://github.com/user-attachments/assets/b65b5886-1589-4c14-8731-e159e37f0ce2" />

 - PC사이즈에서 데이터 없을 때'
 
 - <img width="1880" height="850" alt="image" src="https://github.com/user-attachments/assets/d269fe07-f4cc-45b4-b4c1-b69f9c98daee" />

- <img width="1881" height="860" alt="image" src="https://github.com/user-attachments/assets/529e61db-1775-4792-ad30-bf5f34dfa45e" />




**기능 동작 영상**

**추가 참고 자료**
