### PR TITLE
[Feat/#210] 인사이트 API 연동 및 관련 훅/컴포넌트 리팩터링

### DIFF
--- a/src/api/insightApi.ts
+++ b/src/api/insightApi.ts
@@ -1,0 +1,18 @@
+import { getRequest } from '@/api';
+import { ApiMonthlyInsightResponse, ApiWeeklyInsightResponse } from '@/interfaces/insight';
+
+export const getWeeklyInsight = async (date: string): Promise<ApiWeeklyInsightResponse> => {
+  const apiResponse: ApiWeeklyInsightResponse = await getRequest(
+    `/heatmaps/todo-timers/insight/weekly/${date}`,
+  );
+
+  return apiResponse;
+};
+
+export const getMonthlyInsight = async (yearMonth: string): Promise<ApiMonthlyInsightResponse> => {
+  const apiResponse: ApiMonthlyInsightResponse = await getRequest(
+    `/heatmaps/todo-timers/insight/monthly/${yearMonth}`,
+  );
+
+  return apiResponse;
+};

--- a/src/components/heatmaps/HeatmapSection.tsx
+++ b/src/components/heatmaps/HeatmapSection.tsx
@@ -59,12 +59,7 @@ export default function HeatmapSection() {
         return <InsightCard variant="no-data" />;
       }
 
-      // insights가 배열이고 비어있거나, 모든 요소가 빈 문자열인 경우
-      if (
-        !weeklyInsightData.data.insights ||
-        weeklyInsightData.data.insights.length === 0 ||
-        weeklyInsightData.data.insights.every(insight => insight.trim() === '')
-      ) {
+      if (!weeklyInsightData.data.insights || weeklyInsightData.data.insights.trim() === '') {
         return <InsightCard variant="no-work-time" />;
       }
 
@@ -76,12 +71,7 @@ export default function HeatmapSection() {
         return <InsightCard variant="no-data" />;
       }
 
-      // insights가 배열이고 비어있거나, 모든 요소가 빈 문자열인 경우
-      if (
-        !monthlyInsightData.data.insights ||
-        monthlyInsightData.data.insights.length === 0 ||
-        monthlyInsightData.data.insights.every(insight => insight.trim() === '')
-      ) {
+      if (!monthlyInsightData.data.insights || monthlyInsightData.data.insights.trim() === '') {
         return <InsightCard variant="no-work-time" />;
       }
 

--- a/src/components/heatmaps/HeatmapSection.tsx
+++ b/src/components/heatmaps/HeatmapSection.tsx
@@ -54,22 +54,28 @@ export default function HeatmapSection() {
 
   // 인사이트 카드 렌더링
   const renderInsightCard = () => {
-    // return <InsightCard variant="no-work-time" />;
-
     if (period === 'week') {
-      return weeklyInsightData?.success && weeklyInsightData.data.insights ? (
-        <InsightCard variant="weekly" item={weeklyInsightData.data.insights} />
-      ) : (
-        <InsightCard variant="no-data" />
-      );
+      if (!weeklyInsightData || !weeklyInsightData.success) {
+        return <InsightCard variant="no-data" />;
+      }
+
+      if (!weeklyInsightData.data.insights || weeklyInsightData.data.insights.trim() === '') {
+        return <InsightCard variant="no-work-time" />;
+      }
+
+      return <InsightCard variant="weekly" item={weeklyInsightData.data.insights} />;
     }
 
     if (period === 'month') {
-      return monthlyInsightData?.success && monthlyInsightData.data.insights ? (
-        <InsightCard variant="monthly" item={monthlyInsightData.data.insights} />
-      ) : (
-        <InsightCard variant="no-data" />
-      );
+      if (!monthlyInsightData || !monthlyInsightData.success) {
+        return <InsightCard variant="no-data" />;
+      }
+
+      if (!monthlyInsightData.data.insights || monthlyInsightData.data.insights.trim() === '') {
+        return <InsightCard variant="no-work-time" />;
+      }
+
+      return <InsightCard variant="monthly" item={monthlyInsightData.data.insights} />;
     }
 
     return null;

--- a/src/components/heatmaps/HeatmapSection.tsx
+++ b/src/components/heatmaps/HeatmapSection.tsx
@@ -59,7 +59,12 @@ export default function HeatmapSection() {
         return <InsightCard variant="no-data" />;
       }
 
-      if (!weeklyInsightData.data.insights || weeklyInsightData.data.insights.trim() === '') {
+      // insights가 배열이고 비어있거나, 모든 요소가 빈 문자열인 경우
+      if (
+        !weeklyInsightData.data.insights ||
+        weeklyInsightData.data.insights.length === 0 ||
+        weeklyInsightData.data.insights.every(insight => insight.trim() === '')
+      ) {
         return <InsightCard variant="no-work-time" />;
       }
 
@@ -71,7 +76,12 @@ export default function HeatmapSection() {
         return <InsightCard variant="no-data" />;
       }
 
-      if (!monthlyInsightData.data.insights || monthlyInsightData.data.insights.trim() === '') {
+      // insights가 배열이고 비어있거나, 모든 요소가 빈 문자열인 경우
+      if (
+        !monthlyInsightData.data.insights ||
+        monthlyInsightData.data.insights.length === 0 ||
+        monthlyInsightData.data.insights.every(insight => insight.trim() === '')
+      ) {
         return <InsightCard variant="no-work-time" />;
       }
 

--- a/src/components/heatmaps/HeatmapSection.tsx
+++ b/src/components/heatmaps/HeatmapSection.tsx
@@ -19,8 +19,14 @@ export default function HeatmapSection() {
   const [period, setPeriod] = useState<'week' | 'month'>('week');
   const isWeek = period === 'week';
 
-  const { weeklyHeatmapData, monthlyHeatmapData, hasError, handleRetry } =
-    useHeatmapSection(period);
+  const {
+    weeklyHeatmapData,
+    weeklyInsightData,
+    monthlyHeatmapData,
+    monthlyInsightData,
+    hasError,
+    handleRetry,
+  } = useHeatmapSection(period);
 
   const infoButtonRef = useRef<HTMLButtonElement>(null);
   const cardContainerRef = useRef<HTMLDivElement>(null);
@@ -48,26 +54,25 @@ export default function HeatmapSection() {
 
   // 인사이트 카드 렌더링
   const renderInsightCard = () => {
-    return <InsightCard variant="no-work-time" />;
+    // return <InsightCard variant="no-work-time" />;
 
-    // TODO
-    // if (period === 'week') {
-    //   return weeklyInsightData?.success && weeklyInsightData.data.insights.length > 0 ? (
-    //     <InsightCard variant="weekly" items={weeklyInsightData.data.insights} />
-    //   ) : (
-    //     <InsightCard variant="no-data" />
-    //   );
-    // }
+    if (period === 'week') {
+      return weeklyInsightData?.success && weeklyInsightData.data.insights ? (
+        <InsightCard variant="weekly" item={weeklyInsightData.data.insights} />
+      ) : (
+        <InsightCard variant="no-data" />
+      );
+    }
 
-    // if (period === 'month') {
-    //   return monthlyInsightData?.success && monthlyInsightData.data.insights.length > 0 ? (
-    //     <InsightCard variant="monthly" items={monthlyInsightData.data.insights} />
-    //   ) : (
-    //     <InsightCard variant="no-data" />
-    //   );
-    // }
+    if (period === 'month') {
+      return monthlyInsightData?.success && monthlyInsightData.data.insights ? (
+        <InsightCard variant="monthly" item={monthlyInsightData.data.insights} />
+      ) : (
+        <InsightCard variant="no-data" />
+      );
+    }
 
-    // return null;
+    return null;
   };
 
   const cardTitle = (

--- a/src/components/insight/InsightCard.tsx
+++ b/src/components/insight/InsightCard.tsx
@@ -19,8 +19,8 @@ const InsightCard = ({ variant, item = '', className }: InsightCardProps) => {
           <TimerIcon className="text-inactive" width={32} height={32} fill="currentColor" />
 
           <p>
-            이번 주 작업 기록이 없어 <br className="md:hidden" />
-            인사이트를 제공할 수 없어요 :(
+            작업 기록을 불러올 수 없어요 <br className="md:hidden" />
+            잠시 후 다시 시도해주세요 :(
           </p>
           <p>작업을 시작해보세요!</p>
         </div>

--- a/src/components/insight/InsightCard.tsx
+++ b/src/components/insight/InsightCard.tsx
@@ -2,7 +2,7 @@ import { cn } from '@/lib/utils';
 
 interface InsightCardProps {
   variant: 'no-data' | 'no-work-time' | 'weekly' | 'monthly';
-  item?: string;
+  item?: string | string[];
   className?: string;
 }
 
@@ -47,11 +47,15 @@ const InsightCard = ({ variant, item = '', className }: InsightCardProps) => {
   const title =
     variant === 'weekly' ? '[이번 주 목표 달성 인사이트]' : '[이번 달 목표 달성 인사이트]';
 
+  const insights = Array.isArray(item) ? item : [item];
+
   return (
     <div className={cn(baseClasses, className)}>
       <div className="text-text-01 text-body-b-16">{title}</div>
       <div className="text-body-16 text-text-01 flex flex-col gap-10 leading-tight">
-        <p>{item}</p>
+        {insights.map((insight, index) => (
+          <p key={index}>{insight}</p>
+        ))}
       </div>
     </div>
   );

--- a/src/components/insight/InsightCard.tsx
+++ b/src/components/insight/InsightCard.tsx
@@ -2,13 +2,13 @@ import { cn } from '@/lib/utils';
 
 interface InsightCardProps {
   variant: 'no-data' | 'no-work-time' | 'weekly' | 'monthly';
-  items?: React.ReactNode[];
+  item?: string;
   className?: string;
 }
 
 import TimerIcon from '@/assets/icons/timer.svg';
 
-const InsightCard = ({ variant, items = [], className }: InsightCardProps) => {
+const InsightCard = ({ variant, item = '', className }: InsightCardProps) => {
   const baseClasses =
     'rounded-20 flex w-full flex-col py-12 px-12 md:px-20 bg-insightContainer gap-12 h-full';
 
@@ -51,9 +51,7 @@ const InsightCard = ({ variant, items = [], className }: InsightCardProps) => {
     <div className={cn(baseClasses, className)}>
       <div className="text-text-01 text-body-b-16">{title}</div>
       <div className="text-body-16 text-text-01 flex flex-col gap-10 leading-tight">
-        {items.map((item, idx) => (
-          <p key={idx}>{item}</p>
-        ))}
+        <p>{item}</p>
       </div>
     </div>
   );

--- a/src/components/insight/InsightCard.tsx
+++ b/src/components/insight/InsightCard.tsx
@@ -2,7 +2,7 @@ import { cn } from '@/lib/utils';
 
 interface InsightCardProps {
   variant: 'no-data' | 'no-work-time' | 'weekly' | 'monthly';
-  item?: string | string[];
+  item?: string;
   className?: string;
 }
 

--- a/src/components/insight/InsightCard.tsx
+++ b/src/components/insight/InsightCard.tsx
@@ -47,15 +47,11 @@ const InsightCard = ({ variant, item = '', className }: InsightCardProps) => {
   const title =
     variant === 'weekly' ? '[이번 주 목표 달성 인사이트]' : '[이번 달 목표 달성 인사이트]';
 
-  const insights = Array.isArray(item) ? item : [item];
-
   return (
     <div className={cn(baseClasses, className)}>
       <div className="text-text-01 text-body-b-16">{title}</div>
       <div className="text-body-16 text-text-01 flex flex-col gap-10 leading-tight">
-        {insights.map((insight, index) => (
-          <p key={index}>{insight}</p>
-        ))}
+        <p>{item}</p>
       </div>
     </div>
   );

--- a/src/hooks/useHeatmap.ts
+++ b/src/hooks/useHeatmap.ts
@@ -10,8 +10,6 @@ export const useWeeklyHeatmap = (date: string, opts?: Opts) => {
     queryKey: ['weeklyHeatmap', date],
     queryFn: () => getWeeklyHeatmap(date),
     enabled: !!date && (opts?.enabled ?? true),
-    refetchInterval: 10 * 1000, // 10초마다 새로고침
-    refetchOnWindowFocus: true, // 윈도우 포커스 시 새로고침
   });
 };
 
@@ -20,7 +18,5 @@ export const useMonthlyHeatmap = (yearMonth: string, opts?: Opts) => {
     queryKey: ['monthlyHeatmap', yearMonth],
     queryFn: () => getMonthlyHeatmap(yearMonth),
     enabled: !!yearMonth && (opts?.enabled ?? true),
-    refetchInterval: 10 * 1000, // 10초마다 새로고침
-    refetchOnWindowFocus: true, // 윈도우 포커스 시 새로고침
   });
 };

--- a/src/hooks/useHeatmapsSection.ts
+++ b/src/hooks/useHeatmapsSection.ts
@@ -13,8 +13,8 @@ export const useHeatmapSection = (period: 'week' | 'month') => {
 
   const weeklyHeatmap = useWeeklyHeatmap(getCurrentDate(), { enabled: isWeek });
   const monthlyHeatmap = useMonthlyHeatmap(getCurrentMonth(), { enabled: !isWeek });
-  const weeklyInsight = useWeeklyInsight();
-  const monthlyInsight = useMonthlyInsight();
+  const weeklyInsight = useWeeklyInsight(getCurrentDate());
+  const monthlyInsight = useMonthlyInsight(getCurrentMonth());
 
   const currentHeatmap = isWeek ? weeklyHeatmap : monthlyHeatmap;
   const currentInsight = isWeek ? weeklyInsight : monthlyInsight;

--- a/src/hooks/useHeatmapsSection.ts
+++ b/src/hooks/useHeatmapsSection.ts
@@ -13,8 +13,8 @@ export const useHeatmapSection = (period: 'week' | 'month') => {
 
   const weeklyHeatmap = useWeeklyHeatmap(getCurrentDate(), { enabled: isWeek });
   const monthlyHeatmap = useMonthlyHeatmap(getCurrentMonth(), { enabled: !isWeek });
-  const weeklyInsight = useWeeklyInsight(getCurrentDate());
-  const monthlyInsight = useMonthlyInsight(getCurrentMonth());
+  const weeklyInsight = useWeeklyInsight(getCurrentDate(), { enabled: isWeek });
+  const monthlyInsight = useMonthlyInsight(getCurrentMonth(), { enabled: !isWeek });
 
   const currentHeatmap = isWeek ? weeklyHeatmap : monthlyHeatmap;
   const currentInsight = isWeek ? weeklyInsight : monthlyInsight;

--- a/src/hooks/useInsight.ts
+++ b/src/hooks/useInsight.ts
@@ -8,7 +8,7 @@ type Opts = { enabled?: boolean };
 export const useWeeklyInsight = (date: string, opts?: Opts) => {
   return useQuery<ApiWeeklyInsightResponse>({
     queryKey: ['weeklyInsight', date],
-    queryFn: async () => getWeeklyInsight(date),
+    queryFn: () => getWeeklyInsight(date),
     enabled: !!date && (opts?.enabled ?? true),
   });
 };
@@ -16,7 +16,7 @@ export const useWeeklyInsight = (date: string, opts?: Opts) => {
 export const useMonthlyInsight = (yearMonth: string, opts?: Opts) => {
   return useQuery<ApiMonthlyInsightResponse>({
     queryKey: ['monthlyInsight', yearMonth],
-    queryFn: async () => getMonthlyInsight(yearMonth),
+    queryFn: () => getMonthlyInsight(yearMonth),
     enabled: !!yearMonth && (opts?.enabled ?? true),
   });
 };

--- a/src/hooks/useInsight.ts
+++ b/src/hooks/useInsight.ts
@@ -3,16 +3,20 @@ import { useQuery } from '@tanstack/react-query';
 import { getMonthlyInsight, getWeeklyInsight } from '@/api/insightApi';
 import { ApiMonthlyInsightResponse, ApiWeeklyInsightResponse } from '@/interfaces/insight';
 
-export const useWeeklyInsight = (date: string) => {
+type Opts = { enabled?: boolean };
+
+export const useWeeklyInsight = (date: string, opts?: Opts) => {
   return useQuery<ApiWeeklyInsightResponse>({
     queryKey: ['weeklyInsight', date],
     queryFn: async () => getWeeklyInsight(date),
+    enabled: !!date && (opts?.enabled ?? true),
   });
 };
 
-export const useMonthlyInsight = (yearMonth: string) => {
+export const useMonthlyInsight = (yearMonth: string, opts?: Opts) => {
   return useQuery<ApiMonthlyInsightResponse>({
     queryKey: ['monthlyInsight', yearMonth],
     queryFn: async () => getMonthlyInsight(yearMonth),
+    enabled: !!yearMonth && (opts?.enabled ?? true),
   });
 };

--- a/src/hooks/useInsight.ts
+++ b/src/hooks/useInsight.ts
@@ -1,23 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { MonthlyInsightResponse, WeeklyInsightResponse } from '@/interfaces/insight';
+import { getMonthlyInsight, getWeeklyInsight } from '@/api/insightApi';
+import { ApiMonthlyInsightResponse, ApiWeeklyInsightResponse } from '@/interfaces/insight';
 
-export const useWeeklyInsight = () => {
-  return useQuery<WeeklyInsightResponse>({
-    queryKey: ['weeklyInsight'],
-    queryFn: async () => {
-      const res = await fetch('/insights/weekly');
-      return res.json();
-    },
+export const useWeeklyInsight = (date: string) => {
+  return useQuery<ApiWeeklyInsightResponse>({
+    queryKey: ['weeklyInsight', date],
+    queryFn: async () => getWeeklyInsight(date),
   });
 };
 
-export const useMonthlyInsight = () => {
-  return useQuery<MonthlyInsightResponse>({
-    queryKey: ['monthlyInsight'],
-    queryFn: async () => {
-      const res = await fetch('/insights/monthly');
-      return res.json();
-    },
+export const useMonthlyInsight = (yearMonth: string) => {
+  return useQuery<ApiMonthlyInsightResponse>({
+    queryKey: ['monthlyInsight', yearMonth],
+    queryFn: async () => getMonthlyInsight(yearMonth),
   });
 };

--- a/src/interfaces/insight.ts
+++ b/src/interfaces/insight.ts
@@ -3,7 +3,7 @@ export interface ApiWeeklyInsightResponse {
   success: boolean;
   data: {
     date: string;
-    insights: string;
+    insights: string[];
   };
 }
 
@@ -11,6 +11,6 @@ export interface ApiMonthlyInsightResponse {
   success: boolean;
   data: {
     yearMonth: string;
-    insights: string;
+    insights: string[];
   };
 }

--- a/src/interfaces/insight.ts
+++ b/src/interfaces/insight.ts
@@ -1,19 +1,16 @@
-// 주간 인사이트 응답 데이터 형식
-export interface WeeklyInsightResponse {
+// API 명세서 기반 응답 타입
+export interface ApiWeeklyInsightResponse {
   success: boolean;
   data: {
-    week_start: string;
-    week_end: string;
-    insights: string[];
+    date: string;
+    insights: string;
   };
 }
 
-// 월간 인사이트 응답 데이터 형식
-export interface MonthlyInsightResponse {
+export interface ApiMonthlyInsightResponse {
   success: boolean;
   data: {
-    month: string;
-    month_name: string;
-    insights: string[];
+    yearMonth: string;
+    insights: string;
   };
 }

--- a/src/interfaces/insight.ts
+++ b/src/interfaces/insight.ts
@@ -3,7 +3,7 @@ export interface ApiWeeklyInsightResponse {
   success: boolean;
   data: {
     date: string;
-    insights: string[];
+    insights: string;
   };
 }
 
@@ -11,6 +11,6 @@ export interface ApiMonthlyInsightResponse {
   success: boolean;
   data: {
     yearMonth: string;
-    insights: string[];
+    insights: string;
   };
 }

--- a/src/mocks/handlers/insightHandlers.ts
+++ b/src/mocks/handlers/insightHandlers.ts
@@ -4,11 +4,11 @@ import { monthlyInsightRes } from '@/mocks/mockResponses/insight/monthlyInsightR
 import { weeklyInsightRes } from '@/mocks/mockResponses/insight/weeklyInsightResponse';
 
 export const insightsHandlers = [
-  http.get('/insights/weekly', async () => {
+  http.get('/heatmaps/todo-timers/insight/weekly/:date', async () => {
     return HttpResponse.json(weeklyInsightRes);
   }),
 
-  http.get('/insights/monthly', () => {
+  http.get('/heatmaps/todo-timers/insight/monthly/:yearMonth', () => {
     return HttpResponse.json(monthlyInsightRes);
   }),
 ];

--- a/src/mocks/mockResponses/insight/monthlyInsightResponse.ts
+++ b/src/mocks/mockResponses/insight/monthlyInsightResponse.ts
@@ -1,12 +1,7 @@
 export const monthlyInsightRes = {
   success: true,
   data: {
-    month: '2024-01',
-    month_name: '1월',
-    insights: [
-      '월초 대비 월말 작업량 23.5% 증가! 꾸준한 상승세',
-      '오후 집중도가 월간 베스트!',
-      '이번달 총 작업시간 213시간 45분, 지난달보다 33시간 45분 증가',
-    ],
+    yearMonth: '2025-09',
+    insights: '이번 달은 1주 차를 열심히 보냈네요!',
   },
 };

--- a/src/mocks/mockResponses/insight/weeklyInsightResponse.ts
+++ b/src/mocks/mockResponses/insight/weeklyInsightResponse.ts
@@ -1,11 +1,7 @@
 export const weeklyInsightRes = {
   success: true,
   data: {
-    week_start: '2024-01-01',
-    week_end: '2024-01-07',
-    insights: [
-      '이번주는 금요일이 10시간 20분으로 최고',
-      '이번주는 오후 집중도가 최고! 총 23시간 30분으로 압도적',
-    ],
+    date: '2025-09-02',
+    insights: '이번 주 골든 타임 1회 달성!',
   },
 };

--- a/src/stories/insight/InsightCard.stories.tsx
+++ b/src/stories/insight/InsightCard.stories.tsx
@@ -38,17 +38,13 @@ export const NoData: Story = {
 export const Weekly: Story = {
   args: {
     variant: 'weekly',
-    items: ['아침 시간대의 집중력이 높아요.', '목표 3개 중 2개를 성공적으로 달성했어요.'],
+    item: '이번 주 골든 타임 1회 달성!',
   },
 };
 
 export const Monthly: Story = {
   args: {
     variant: 'monthly',
-    items: [
-      '가장 많이 활동한 요일은 화요일이에요.',
-      '전체 목표 달성률은 85%입니다.',
-      '작업 시간은 평균 3.2시간으로 꾸준했어요.',
-    ],
+    item: '이번 달은 1주 차를 열심히 보냈네요!',
   },
 };


### PR DESCRIPTION

## 🔗 관련 이슈 번호 (Related Issue Number)

> 이 Pull Request가 해결하고자 하는 이슈의 번호를 기재합니다. 이슈 연결을 통해 작업의 배경과 목적을 쉽게 파악할 수 있습니다. (예: Closes #123)

- Closes #210

---

## ✨ PR 세부 내용 (PR Details)

> 이번 PR에서 어떤 작업을 했는지 상세하게 설명합니다. 코드 변경의 이유, 구현 방식, 주요 로직 등을 중심으로 작성하면 리뷰어가 이해하는 데 도움이 됩니다.

**작업 개요**
- 인사이트 데이터 구조를 API 기반으로 통합
- 관련 훅(useInsight, useHeatmapSection), 컴포넌트(InsightCard, HeatmapSection) 및 목(mock) 데이터를 리팩터링

**주요 변경사항**
- src/api/insightApi.ts 에 API 도입
  - `getWeeklyInsight(date)`
  - `getMonthlyInsight(yearMonth) `
- src/hooks/useInsight.ts 의 훅 정리
  - 기존 fetch 로직 제거 → insightApi 호출로 전환
  - `opts?: { enabled?: boolean }` 추가, enabled: !!param && (opts?.enabled ?? true)로 조건 실행
- src/hooks/useHeatmapsSection.ts
    - `useWeeklyInsight(getCurrentDate(), { enabled: isWeek })`, `useMonthlyInsight(getCurrentMonth(), { enabled: !isWeek })`로 탭 상태에 따라 활성화