### PR TITLE
[Feat/#321] 노트 사이드바 전역 상태 관리 및 반응형 레이아웃 구현

### DIFF
--- a/src/app/(main)/goal/notes/page.tsx
+++ b/src/app/(main)/goal/notes/page.tsx
@@ -1,4 +1,11 @@
+'use client';
+
+import React, { useState } from 'react';
+
+import { useNoteSidebar } from '@/app/providers/NoteSidebarProvider';
 import NotesClient from '@/components/notes/NotesClient';
+import NoteSidebar from '@/components/ui/NoteSidebar/NoteSidebar';
+import { TodoWithNotes } from '@/interfaces/todo';
 import { cn } from '@/lib/utils';
 
 interface NotesPageProps {
@@ -7,14 +14,55 @@ interface NotesPageProps {
   }>;
 }
 
-const NotesPage = async ({ searchParams }: NotesPageProps) => {
-  const params = await searchParams;
+const NotesPage = ({ searchParams }: NotesPageProps) => {
+  const params = React.use(searchParams);
   const goalId = params.goalId ? Number(params.goalId) : undefined;
 
+  const { setIsNoteSidebarOpen } = useNoteSidebar(); // 사이드바 열림 여부
+  const [selectedTodo, setSelectedTodo] = useState<TodoWithNotes | null>(null);
+
+  const handleTodoClick = (todo: TodoWithNotes) => {
+    setSelectedTodo(todo);
+    setIsNoteSidebarOpen(true);
+  };
+
+  const handleCloseSidebar = () => {
+    setIsNoteSidebarOpen(false);
+    setSelectedTodo(null);
+  };
+
   return (
-    <div className={cn('h-full w-full sm:mt-54 md:mt-0 lg:mt-0')}>
-      <NotesClient initialGoalId={goalId} />
-    </div>
+    <>
+      <div className={cn('h-full w-full sm:mt-54 md:mt-0 lg:mt-0')}>
+        <NotesClient initialGoalId={goalId} onTodoClick={handleTodoClick} />
+      </div>
+
+      {/* 데스크탑 사이드바 */}
+      {selectedTodo && (
+        <div className="hidden lg:block">
+          <NoteSidebar
+            isOpen={true}
+            todo={selectedTodo}
+            goalTitle={selectedTodo.goalTitle || '목표 없음'}
+            onClose={handleCloseSidebar}
+            isDesktop={true}
+          />
+        </div>
+      )}
+
+      {/* 모바일/태블릿 사이드바 */}
+      {selectedTodo && (
+        <div className="lg:hidden">
+          <NoteSidebar
+            isOpen={true}
+            todo={selectedTodo}
+            goalTitle={selectedTodo.goalTitle || '목표 없음'}
+            onClose={handleCloseSidebar}
+            isDesktop={false}
+          />
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname } from 'next/navigation';
 
-import { NoteSidebarProvider } from '@/app/providers/NoteSidebarProvider';
+import { NoteSidebarProvider, useNoteSidebar } from '@/app/providers/NoteSidebarProvider';
 import { SidebarProvider } from '@/app/providers/SidebarProvider';
 import Sidebar from '@/components/sidebar/Sidebar';
 
@@ -32,10 +32,18 @@ function SidebarLayout({ children }: { children: React.ReactNode }) {
 }
 
 function MainContent({ children }: { children: React.ReactNode }) {
+  const { isNoteSidebarOpen } = useNoteSidebar();
+
   return (
     <main className="flex min-w-0 flex-1 flex-col overflow-y-auto transition-all duration-300">
       <div className="flex w-full flex-1 justify-center sm:px-16 md:pr-13 md:pl-93 lg:px-30">
-        <div className="w-full max-w-1296 sm:py-16 md:py-36">{children}</div>
+        <div
+          className={`w-full max-w-1296 transition-all duration-300 sm:py-16 md:py-36 ${
+            isNoteSidebarOpen ? 'lg:mr-360' : ''
+          }`}
+        >
+          {children}
+        </div>
       </div>
     </main>
   );

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -2,13 +2,16 @@
 
 import { usePathname } from 'next/navigation';
 
+import { NoteSidebarProvider } from '@/app/providers/NoteSidebarProvider';
 import { SidebarProvider } from '@/app/providers/SidebarProvider';
 import Sidebar from '@/components/sidebar/Sidebar';
 
 export default function MainLayout({ children }: { children: React.ReactNode }) {
   return (
     <SidebarProvider>
-      <SidebarLayout>{children}</SidebarLayout>
+      <NoteSidebarProvider>
+        <SidebarLayout>{children}</SidebarLayout>
+      </NoteSidebarProvider>
     </SidebarProvider>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,7 +62,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 
   return (
     <html lang="ko" className={pretendard.variable}>
-      <body className="bg-background min-h-screen">
+      <body className="min-h-screen">
         <AuthProvider initialToken={token}>
           <MswProvider>
             <ReactQueryProvider>{children}</ReactQueryProvider>

--- a/src/app/providers/NoteSidebarProvider.tsx
+++ b/src/app/providers/NoteSidebarProvider.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { createContext, ReactNode, useContext, useState } from 'react';
+
+interface NoteSidebarContextType {
+  isNoteSidebarOpen: boolean;
+  setIsNoteSidebarOpen: (value: boolean) => void;
+}
+
+const NoteSidebarContext = createContext<NoteSidebarContextType | undefined>(undefined);
+
+export const useNoteSidebar = () => {
+  const context = useContext(NoteSidebarContext);
+  if (!context) {
+    throw new Error('useNoteSidebar must be used within a NoteSidebarProvider');
+  }
+  return context;
+};
+
+export const NoteSidebarProvider = ({ children }: { children: ReactNode }) => {
+  const [isNoteSidebarOpen, setIsNoteSidebarOpen] = useState(false);
+
+  return (
+    <NoteSidebarContext.Provider value={{ isNoteSidebarOpen, setIsNoteSidebarOpen }}>
+      {children}
+    </NoteSidebarContext.Provider>
+  );
+};

--- a/src/components/goals/goalDetail/GoalDetailClient.tsx
+++ b/src/components/goals/goalDetail/GoalDetailClient.tsx
@@ -67,7 +67,7 @@ const GoalDetailClient = ({ goalId }: GoalDetailClientProps) => {
   }
 
   return (
-    <div className="h-full w-full overflow-hidden lg:max-w-1184">
+    <div className="h-full w-full overflow-hidden lg:max-w-1296">
       <div className="mx-auto flex h-full w-full flex-col p-6">
         {/* 목표 정보 헤더 */}
         <div className="mb-24 flex flex-shrink-0 items-center gap-8">

--- a/src/components/notes/NotesClient.tsx
+++ b/src/components/notes/NotesClient.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState } from 'react';
 
 import TodoWithNoteList from '@/components/notes/TodoWithNoteList';
 import GoalSelector from '@/components/todos/GoalSelector';
-import NoteSidebar from '@/components/ui/NoteSidebar/NoteSidebar';
 import Pagination from '@/components/ui/Pagination';
 import { useTodosWithNotes } from '@/hooks/useNotes';
 import { TodoWithNotes } from '@/interfaces/todo';
@@ -13,19 +12,17 @@ const ITEMS_PER_PAGE = 6; // 페이지당 표시할 할 일 개수
 
 interface NotesClientProps {
   initialGoalId?: number;
+  onTodoClick: (todo: TodoWithNotes) => void;
 }
 
-const NotesClient = ({ initialGoalId }: NotesClientProps) => {
+const NotesClient = ({ initialGoalId, onTodoClick }: NotesClientProps) => {
   const [selectedGoalId, setSelectedGoalId] = useState<number>(initialGoalId || 0);
-  const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(false);
-  const [selectedTodo, setSelectedTodo] = useState<TodoWithNotes | null>(null);
   const [currentPage, setCurrentPage] = useState<number>(1);
 
   const { data: allTodosWithNotes = [] } = useTodosWithNotes(
     selectedGoalId === 0 ? undefined : selectedGoalId,
   );
 
-  // 페이지네이션 계산
   const paginatedData = useMemo(() => {
     const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
     const endIndex = startIndex + ITEMS_PER_PAGE;
@@ -42,28 +39,17 @@ const NotesClient = ({ initialGoalId }: NotesClientProps) => {
     };
   }, [allTodosWithNotes.length, currentPage]);
 
-  const handleTodoClick = (todo: TodoWithNotes) => {
-    setSelectedTodo(todo);
-    setIsSidebarOpen(true);
-  };
-
-  const handleCloseSidebar = () => {
-    setIsSidebarOpen(false);
-    setSelectedTodo(null);
-  };
-
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
   };
 
-  // 목표 변경 시 페이지 초기화
   const handleGoalChange = (goalId: number) => {
     setSelectedGoalId(goalId);
     setCurrentPage(1);
   };
 
   return (
-    <div className="mx-auto h-full max-w-1296">
+    <div className="h-full w-full">
       <header className="mb-32 sm:mb-44">
         <div className="flex items-center">
           <h1 className="text-text-01 text-display-24 sm:text-display-32 font-bold">
@@ -72,38 +58,25 @@ const NotesClient = ({ initialGoalId }: NotesClientProps) => {
         </div>
       </header>
 
-      <div className="flex">
-        <main className="flex-1">
-          <div className="mb-32 w-full">
-            <GoalSelector
-              selectedGoalId={selectedGoalId}
-              onSelectGoal={handleGoalChange}
-              variant="notes"
-            />
-          </div>
-          <TodoWithNoteList todos={paginatedData} onTodoClick={handleTodoClick} />
+      <main>
+        <div className="mb-32 w-full">
+          <GoalSelector
+            selectedGoalId={selectedGoalId}
+            onSelectGoal={handleGoalChange}
+            variant="notes"
+          />
+        </div>
+        <TodoWithNoteList todos={paginatedData} onTodoClick={onTodoClick} />
 
-          {/* 페이지네이션 */}
-          {paginationInfo.totalPages > 1 && (
-            <Pagination
-              pagination={paginationInfo}
-              onPageChange={handlePageChange}
-              size="md"
-              maxVisiblePages={5}
-            />
-          )}
-        </main>
-      </div>
-
-      {/* 할 일 클릭 시 열리는 사이드바 */}
-      {isSidebarOpen && selectedTodo && (
-        <NoteSidebar
-          isOpen={isSidebarOpen}
-          todo={selectedTodo}
-          goalTitle={selectedTodo.goalTitle || '목표 없음'}
-          onClose={handleCloseSidebar}
-        />
-      )}
+        {paginationInfo.totalPages > 1 && (
+          <Pagination
+            pagination={paginationInfo}
+            onPageChange={handlePageChange}
+            size="md"
+            maxVisiblePages={5}
+          />
+        )}
+      </main>
     </div>
   );
 };

--- a/src/components/notes/NotesClient.tsx
+++ b/src/components/notes/NotesClient.tsx
@@ -63,7 +63,7 @@ const NotesClient = ({ initialGoalId }: NotesClientProps) => {
   };
 
   return (
-    <div className="mx-auto h-full max-w-1184">
+    <div className="mx-auto h-full max-w-1296">
       <header className="mb-32 sm:mb-44">
         <div className="flex items-center">
           <h1 className="text-text-01 text-display-24 sm:text-display-32 font-bold">
@@ -74,7 +74,7 @@ const NotesClient = ({ initialGoalId }: NotesClientProps) => {
 
       <div className="flex">
         <main className="flex-1">
-          <div className="mb-32">
+          <div className="mb-32 w-full">
             <GoalSelector
               selectedGoalId={selectedGoalId}
               onSelectGoal={handleGoalChange}

--- a/src/components/todos/GoalSelector.tsx
+++ b/src/components/todos/GoalSelector.tsx
@@ -112,6 +112,8 @@ const GoalSelector = ({
         size="todo"
         animation="slide"
         shadow="md"
+        matchTriggerWidth
+        offsetPx={2}
         className="max-h-200 w-full overflow-y-auto"
       >
         <div className="py-4">

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -49,7 +49,7 @@ const buttonVariants = cva('flex cursor-pointer items-center justify-center', {
       schedule: 'h-48 w-120 sm:w-165.5',
       scheduleDashboard: 'h-40 w-120 md:w-160',
       tempNote: 'h-40 w-84',
-      sideNote: 'h-48 w-260',
+      sideNote: 'h-40 w-100 md:h-48 md:w-200 lg:w-260',
       error: 'h-44 w-200',
       eula: 'h-48 w-520',
     },

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -25,7 +25,7 @@ const dropdownVariants = cva('rounded-b-[20px] border shadow-lg', {
       lg: 'max-w-md min-w-64',
       auto: 'w-auto max-w-xs',
       goalListFilter: 'max-w-148',
-      todo: 'max-w-520',
+      todo: 'max-w-1296',
       full: 'w-auto',
     },
     animation: {
@@ -56,6 +56,7 @@ export interface DropdownMenuProps extends VariantProps<typeof dropdownVariants>
   position?: 'bottom-start' | 'bottom-end' | 'top-start' | 'top-end';
   matchTriggerWidth?: boolean;
   zIndex?: number;
+  offsetPx?: number;
 }
 
 const DropdownMenu = ({
@@ -70,6 +71,7 @@ const DropdownMenu = ({
   position = 'bottom-start',
   matchTriggerWidth = false,
   zIndex = 9999,
+  offsetPx,
 }: DropdownMenuProps) => {
   // Floating UI 설정
   const { refs, floatingStyles, context } = useFloating({
@@ -78,7 +80,7 @@ const DropdownMenu = ({
       if (!open) onClose();
     },
     middleware: [
-      offset(16), // 16px 간격
+      offset(offsetPx),
       flip(), // 화면 경계에 닿으면 위치 자동 조정
       shift(), // 화면 밖으로 나가지 않도록 이동
       ...(matchTriggerWidth
@@ -87,6 +89,7 @@ const DropdownMenu = ({
               apply({ rects, elements }) {
                 Object.assign(elements.floating.style, {
                   width: `${rects.reference.width}px`,
+                  boxSizing: 'border-box',
                 });
               },
             }),

--- a/src/components/ui/NoteSidebar/NoteDetailReadMode.tsx
+++ b/src/components/ui/NoteSidebar/NoteDetailReadMode.tsx
@@ -40,7 +40,8 @@ const NoteDetailReadMode = ({ note, onEdit, goalTitle, todoTitle }: NoteDetailRe
           className="bg-primary-01 text-white"
           icon={<PencilIcon className="mr-2" />}
         >
-          수정하기
+          <span className="hidden sm:inline md:hidden">수정</span>
+          <span className="hidden md:inline">수정하기</span>
         </Button>
       </div>
     </div>

--- a/src/components/ui/NoteSidebar/NoteSidebar.tsx
+++ b/src/components/ui/NoteSidebar/NoteSidebar.tsx
@@ -10,7 +10,7 @@ interface NoteSidebarProps {
   todo?: TodoWithNotes;
   goalTitle?: string;
   onClose: () => void;
-  isDesktop: boolean;
+  isDesktop?: boolean;
 }
 
 // 2단계 레이어 구조: NoteListSidebar → NoteDetailSidebar

--- a/src/components/ui/NoteSidebar/NoteSidebar.tsx
+++ b/src/components/ui/NoteSidebar/NoteSidebar.tsx
@@ -10,55 +10,85 @@ interface NoteSidebarProps {
   todo?: TodoWithNotes;
   goalTitle?: string;
   onClose: () => void;
+  isDesktop: boolean;
 }
 
-const NoteSidebar = ({ isOpen, todo, goalTitle, onClose }: NoteSidebarProps) => {
+// 2단계 레이어 구조: NoteListSidebar → NoteDetailSidebar
+const NoteSidebar = ({ isOpen, todo, goalTitle, onClose, isDesktop }: NoteSidebarProps) => {
   const [currentView, setCurrentView] = useState<'note-list' | 'note-detail'>('note-list');
-  const [setselectedNoteId, setsetselectedNoteId] = useState<number | null>(null);
+  const [selectedNoteId, setSelectedNoteId] = useState<number | null>(null);
 
   if (!isOpen) return null;
 
   const handleNoteClick = (noteId: number) => {
     setCurrentView('note-detail');
-    setsetselectedNoteId(noteId);
+    setSelectedNoteId(noteId);
   };
 
   const handleBack = () => {
     setCurrentView('note-list');
+    setSelectedNoteId(null);
   };
 
   const handleClose = () => {
     setCurrentView('note-list');
+    setSelectedNoteId(null);
     onClose();
   };
 
   return (
     <>
-      {/* 배경 오버레이 */}
-      <div className="fixed inset-0 z-40 bg-black/50" onClick={handleClose} />
+      {/* ===== 첫 번째 레이어: NoteListSidebar ===== */}
+      {currentView === 'note-list' && (
+        <>
+          {/* 데스크탑: fixed 우측 */}
+          {isDesktop && (
+            <div className="fixed top-0 right-0 z-40 h-full w-336 overflow-y-auto border-l border-gray-200 bg-white shadow-lg">
+              {todo && (
+                <NoteListSidebar todo={todo} onClose={handleClose} onNoteClick={handleNoteClick} />
+              )}
+            </div>
+          )}
 
-      {/* 사이드바 */}
-      <div
-        className={`fixed top-0 right-0 z-50 h-full bg-white shadow-lg transition-transform duration-300 ${
-          currentView === 'note-list'
-            ? 'w-full sm:w-336 md:w-336 lg:w-400' // 노트 목록: 좁은 너비
-            : 'w-full sm:w-full md:w-512 lg:w-800' // 노트 상세: 넓은 너비
-        }`}
-      >
-        {currentView === 'note-list' && todo && (
-          <NoteListSidebar todo={todo} onClose={handleClose} onNoteClick={handleNoteClick} />
-        )}
-        {currentView === 'note-detail' && setselectedNoteId && todo && (
-          <NoteDetailSidebar
-            noteId={setselectedNoteId}
-            todoId={todo.todoId}
-            onClose={handleClose}
-            onBack={handleBack}
-            goalTitle={goalTitle}
-            todoTitle={todo?.name}
-          />
-        )}
-      </div>
+          {/* 모바일/태블릿: fixed 우측 + 오버레이 */}
+          {!isDesktop && (
+            <>
+              <div className="fixed inset-0 z-40 bg-black/50" onClick={handleClose} />
+              <div className="fixed top-0 right-0 z-50 h-full w-full bg-white shadow-lg sm:w-336">
+                {todo && (
+                  <NoteListSidebar
+                    todo={todo}
+                    onClose={handleClose}
+                    onNoteClick={handleNoteClick}
+                  />
+                )}
+              </div>
+            </>
+          )}
+        </>
+      )}
+
+      {/* ===== 두 번째 레이어: NoteDetailSidebar (모달) ===== */}
+      {currentView === 'note-detail' && selectedNoteId && (
+        <>
+          {/* 배경 오버레이 - NoteListSidebar 위를 어둡게 */}
+          <div className="fixed inset-0 z-50 bg-black/50" onClick={handleBack} />
+
+          {/* NoteDetailSidebar 모달 */}
+          <div className="fixed top-0 right-0 z-60 h-full w-full overflow-y-auto bg-white shadow-lg sm:w-full md:w-512 lg:w-800">
+            {todo && (
+              <NoteDetailSidebar
+                noteId={selectedNoteId}
+                todoId={todo.todoId}
+                onClose={handleClose}
+                onBack={handleBack}
+                goalTitle={goalTitle}
+                todoTitle={todo?.name}
+              />
+            )}
+          </div>
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## 📖 스토리북 링크 (Storybook Link)

> 변경된 UI 컴포넌트를 시각적으로 확인하고 인터랙션해볼 수 있는 스토리북 링크를 첨부합니다.

- [바로가기]()

---

## 🔗 관련 이슈 번호 (Related Issue Number)

> 이 Pull Request가 해결하고자 하는 이슈의 번호를 기재합니다. 이슈 연결을 통해 작업의 배경과 목적을 쉽게 파악할 수 있습니다. (예: Closes #123)

- Closes #321
- Closes #322 

---

## ✨ PR 세부 내용 (PR Details)

> 이번 PR에서 어떤 작업을 했는지 상세하게 설명합니다. 코드 변경의 이유, 구현 방식, 주요 로직 등을 중심으로 작성하면 리뷰어가 이해하는 데 도움이 됩니다.

**작업 개요**
- 전반적인 반응형 디자인 디테일 작업 진행
- 노트 사이드바의 전역 상태 관리 및 반응형 레이아웃 개선

**주요 변경사항**
- 전역 상태 관리 추가
  - `NoteSidebarProvider` 추가 및 Context API 기반 상태 관리 도입
  - `layout.tsx`에서 Provider 트리 구성 (`SidebarProvider` → `NoteSidebarProvider`)
- 구조 리팩토링
  - `NotesClient` → UI 렌더링만 담당, 사이드바 제어는 상위 NotesPage로 이동
  - `NotesPage`에서 onTodoClick 콜백을 통해 선택된 할 일을 전역 상태에 전달
- 반응형 사이드바 구현
  - Desktop (≥1440px):
    - 사이드바가 고정(fixed) 위치로 우측에 항상 붙음
    - 메인 콘텐츠(NotesClient)는 lg:mr-360 여백 확보로 자연스러운 레이아웃 유지
  - Mobile/Tablet (<1440px):
    - 오버레이 모달 형태로 노출
    - 배경 블러 및 클릭 시 닫힘 처리 

**기술적 구현 사항**

---

## 📸 참고할 스크린샷/영상 (Screenshots/Videos)

> 작업 내용과 관련된 시각적인 자료가 있다면 첨부합니다. UI 변경이나 새로운 기능의 동작 방식을 보여주는 스크린샷 또는 영상을 활용하면 리뷰어의 이해를 돕습니다.

**UI 변경 전/후 스크린샷**

### 노트 모아보기 
|목표 선택|
|--| 
|<img width="1455" height="541" alt="image" src="https://github.com/user-attachments/assets/120e3a90-50a2-4bf2-9d3f-2e48988870b8" />|
 
### 노트 모아보기 - pc버전
| 메뉴사이드바 open, 노트사이드바 close|메뉴사이드바 open, 노트사이드바 open | 
|--|--|
|<img width="2160" height="1405" alt="image" src="https://github.com/user-attachments/assets/59683eb2-a5eb-4fa6-aa5c-d4ee49e9730c" />|<img width="2157" height="1404" alt="image" src="https://github.com/user-attachments/assets/53df3db0-ad91-4e2d-bc96-a182bdbd63e2" />|

| 메뉴사이드바 close, 노트사이드바 close|메뉴사이드바 close, 노트사이드바 open | 
|--|--|
| <img width="2153" height="1407" alt="image" src="https://github.com/user-attachments/assets/f6a55845-7b98-431b-96d6-9c4224db1e05" />| <img width="2154" height="1405" alt="image" src="https://github.com/user-attachments/assets/a688f427-aafd-4354-b469-d6a13e0f40d8" />|


### 노트 사이드바
|목록|
|--|
|<img width="1457" height="522" alt="image" src="https://github.com/user-attachments/assets/22b3e997-b3c4-479b-af5a-1b147e62ae8e" />|

|읽기모드|
|--|
|<img width="1455" height="517" alt="image" src="https://github.com/user-attachments/assets/aa3c0421-d6e9-488b-a18f-0919fcaee9cd" />|

|수정모드|
|--|
|<img width="1463" height="516" alt="image" src="https://github.com/user-attachments/assets/811e0286-2a78-4be8-a8df-a28a13dea73f" />|